### PR TITLE
Fixes url escaping

### DIFF
--- a/index.json
+++ b/index.json
@@ -748,7 +748,7 @@
         "manufacturerCode": 4687,
         "imageType": 0,
         "modelId": "GL-S-007P",
-        "url": "https://github.com/Koenkk/zigbee-OTA/raw/master/images/Gledopto/GL-S-007P_V15_A1_OTAV5_20210201_90%.ota",
+        "url": "https://github.com/Koenkk/zigbee-OTA/raw/master/images/Gledopto/GL-S-007P_V15_A1_OTAV5_20210201_90%25.ota",
         "path": "images/Gledopto/GL-S-007P_V15_A1_OTAV5_20210201_90%.ota"
     }
 ]

--- a/scripts/add.js
+++ b/scripts/add.js
@@ -80,7 +80,7 @@ const main = async () => {
         entry.url = filenameOrURL;
     } else {
         const destinationPosix = destination.replace(/\\/g, '/');
-        entry.url = `${baseURL}/${destinationPosix}`;
+        entry.url = `${baseURL}/${escape(destinationPosix)}`;
         entry.path = destinationPosix;
     }
 


### PR DESCRIPTION
Using the add.js will set a unescaped url that won't actually work to retrieve the file, this fixes that.