### PR TITLE
Fix image parsing when the upgrade file identifier is not at position 0

### DIFF
--- a/lib/ota.js
+++ b/lib/ota.js
@@ -8,7 +8,10 @@ function parseSubElement(buffer, position) {
     return {tagID, length, data};
 }
 
-function parseImage(buffer) {
+function parseImage(rawBuffer) {
+    const start = rawBuffer.indexOf(upgradeFileIdentifier);
+    const buffer = rawBuffer.slice(start);
+
     const header = {
         otaUpgradeFileIdentifier: buffer.subarray(0, 4),
         otaHeaderVersion: buffer.readUInt16LE(4),


### PR DESCRIPTION
Hi,

On some OTA firmwares, the upgrade file identifier ([0x1E, 0xF1, 0xEE, 0x0B]) doesn't start at 0. z2m has the right code to detect it but not this repository which prevent to detect some firmwares properly : in my case some Legrand that I'm working on to test for a future integration.