### PR TITLE
Update Philips Hue smart plug firmware

### DIFF
--- a/index.json
+++ b/index.json
@@ -183,12 +183,12 @@
         "url": "http://fds.dc1.philips.com/firmware/ZGB_100B_0114/16784128/100B-0114-01001B00-ConfLightBLE-Lamps-EFR32MG21.zigbee"
     },
     {
-        "fileVersion": 16780544,
-        "fileSize": 385342,
+        "fileVersion": 16780800,
+        "fileSize": 385466,
         "manufacturerCode": 4107,
         "imageType": 277,
-        "sha512": "0f7176e803a55c3d6bcf29c341e51d09a963a0f5f37bdbb7f824f1b6f950a7f8c99b9e0afd551bf3e6410b657a2771b494d30448593857cbe317b6c1ad3466fc",
-        "url": "http://fds.dc1.philips.com/firmware/ZGB_100B_0115/16780544/100B-0115-01000D00-SmartPlug-EFR32MG13.zigbee"
+        "sha512": "c861e0dfadb0d695fac845c535f0faddbfb682931b324da0ad0e3e2d006295823725e16f08eb7672d11ae3c9621e571759813e9a1b0e07120ee3933f89752f57",
+        "url": "http://fds.dc1.philips.com/firmware/ZGB_100B_0115/16780800/100B-0115-01000E00-SmartPlug-EFR32MG13.zigbee"
     },
     {
         "fileVersion": 33566472,

--- a/index.json
+++ b/index.json
@@ -183,12 +183,12 @@
         "url": "http://fds.dc1.philips.com/firmware/ZGB_100B_0114/16784128/100B-0114-01001B00-ConfLightBLE-Lamps-EFR32MG21.zigbee"
     },
     {
-        "fileVersion": 16780800,
-        "fileSize": 385466,
+        "fileVersion": 16781056,
+        "fileSize": 385678,
         "manufacturerCode": 4107,
         "imageType": 277,
-        "sha512": "c861e0dfadb0d695fac845c535f0faddbfb682931b324da0ad0e3e2d006295823725e16f08eb7672d11ae3c9621e571759813e9a1b0e07120ee3933f89752f57",
-        "url": "http://fds.dc1.philips.com/firmware/ZGB_100B_0115/16780800/100B-0115-01000E00-SmartPlug-EFR32MG13.zigbee"
+        "sha512": "ffbab6ed1c88d9188ad68f8b4744a0e108955fa3b77744f53d213bfc9b1a134320d64f388b34a3c8b9073c637861009dca19b7902f34d5b9a7fb548c294ec95b",
+        "url": "http://fds.dc1.philips.com/firmware/ZGB_100B_0115/16781056/100B-0115-01000F00-SmartPlug-EFR32MG13.zigbee"
     },
     {
         "fileVersion": 33566472,

--- a/index.json
+++ b/index.json
@@ -183,12 +183,12 @@
         "url": "http://fds.dc1.philips.com/firmware/ZGB_100B_0114/16784128/100B-0114-01001B00-ConfLightBLE-Lamps-EFR32MG21.zigbee"
     },
     {
-        "fileVersion": 16780032,
-        "fileSize": 391086,
+        "fileVersion": 16780544,
+        "fileSize": 385342,
         "manufacturerCode": 4107,
         "imageType": 277,
-        "sha512": "561f6323d8184a63ddc54060e56ee6e58d8acc19fc2ef0a5165de32830dac45a66927d95f78a944344110e20105675fafc4775c92670b0e782668e5663b6bd59",
-        "url": "http://fds.dc1.philips.com/firmware/ZGB_100B_0115/16780032/100B-0115-01000B00-SmartPlug-EFR32MG13.zigbee"
+        "sha512": "0f7176e803a55c3d6bcf29c341e51d09a963a0f5f37bdbb7f824f1b6f950a7f8c99b9e0afd551bf3e6410b657a2771b494d30448593857cbe317b6c1ad3466fc",
+        "url": "http://fds.dc1.philips.com/firmware/ZGB_100B_0115/16780544/100B-0115-01000D00-SmartPlug-EFR32MG13.zigbee"
     },
     {
         "fileVersion": 33566472,


### PR DESCRIPTION
Updates the firmware for the Hue smart plug to 1.93.6 (https://www.philips-hue.com/en-us/support/release-notes/accessories).

Commits for intermediate versions between the now and the latest version have been included for posterity - they might be useful for some reason later.
