### PR TITLE
Add linter to automatically validate changes

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,30 @@
+# This workflow executes several linters on changed files based on languages used in your code base whenever
+# you push a code or open a pull request.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/github/super-linter
+name: Lint Code Base
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  run-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          FILTER_REGEX_EXCLUDE: .*images/.*
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # zigbee-OTA
+
+[![Lint Code Base status badge](https://github.com/Koenkk/zigbee-OTA/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/Koenkk/zigbee-OTA/actions/workflows/linter.yml)
+
 A collection of Zigbee OTA files, see `index.json` for an overview of all available firmware files.
 
 ## Adding new and updating existing OTA files
+
 1. Go to this directory
 2. Execute `node scripts/add.js PATH_TO_OTA_FILE_OR_URL`, e.g.:
     - `node scripts/add.js ~/Downloads/WhiteLamp-Atmel-Target_0105_5.130.1.30000_0012.sbl-ota`
     - `node scripts/add.js http://fds.dc1.philips.com/firmware/ZGB_100B_010D/1107323831/Sensor-ATmega_6.1.1.27575_0012.sbl-ota`
-3. Create a PR
+3. Create a PR. Changes will be automatically validated by GitHub.
 
-## Updating all existing OTA entries (if add.js has been changed)
+## Updating all existing OTA entries (if `add.js` has been changed)
+
 1. Go to this directory
 2. Execute `node scripts/updateall.js`
-3. Create a PR
+3. Create a PR. Changes will be automatically validated by GitHub.


### PR DESCRIPTION
This adds a GitHub Action CI workflow for linting changes made to the codebase and open PRs.  This will automatically check `index.json` (and other files in the repo as they are added or modified, excluding `images/`) for validity, helping check changes before merging.  An example linter run is attached to this PR itself, note that this run passes as the linter only checks the diff in the current PR/commit.

It's possible to go further and validate the structure of `index.json` against a schema, but for now, this helps avoid syntax errors (see https://github.com/Koenkk/zigbee-OTA/pull/107).

