### PR TITLE
Create OTA_URLs.md to collect external URLs

### DIFF
--- a/OTA_URLs.md
+++ b/OTA_URLs.md
@@ -1,0 +1,87 @@
+# Zigbee OTA source provider sources for these and others
+
+Collection of external Zigbee OTA firmware images from official and unofficial OTA provider sources.
+
+### Koenkk zigbee-OTA repository
+
+Koenkk zigbee-OTA repository host third-party OTA firmware images and external URLs for many third-party Zigbee OTA firmware images.
+
+https://github.com/Koenkk/zigbee-OTA/tree/master/images
+
+https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/index.json
+
+### Dresden Elektronik
+
+Dresden Elektronik Zigbee OTA firmware images are made publicly available by Dresden Elektronik (first-party) at the following URL:
+
+https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/OTA-Image-Types---Firmware-versions
+
+Dresden Elektronik also provide third-party OTA firmware images and external URLs for many third-party Zigbee OTA firmware images.
+
+### EUROTRONICS
+
+EUROTRONICS Zigbee OTA firmware images are made publicly available by EUROTRONIC Technology (first-party) at the following URL:
+
+https://github.com/EUROTRONIC-Technology/Spirit-ZigBee/releases/download/
+
+### IKEA Trådfri 
+
+IKEA Tradfi Zigbee OTA firmware images are made publicly available by IKEA (first-party) at the following URL:
+
+Download-URL: 
+
+http://fw.ota.homesmart.ikea.net/feed/version_info.json
+
+Download-URL (Test/Beta-Version): 
+
+http://fw.test.ota.homesmart.ikea.net/feed/version_info.json
+
+Release changelogs
+
+https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html
+
+### LEDVANCE/Sylvania and OSRAM Lightify
+
+LEDVANCE/Sylvania and OSRAM Lightify Zigbee OTA firmware images are made publicly available by LEDVANCE (first-party) at the following URL:
+
+https://update.ledvance.com/firmware-overview
+
+https://api.update.ledvance.com/v1/zigbee/firmwares/download
+
+https://consumer.sylvania.com/our-products/smart/sylvania-smart-zigbee-products-menu/index.jsp
+
+### Legrand/Netatmo
+
+Legrand/Netatmo Zigbee OTA firmware images are made publicly available by Legrand (first-party) at the following URL:
+
+https://developer.legrand.com/documentation/operating-manual/ https://developer.legrand.com/documentation/firmwares-download/
+
+### LiXee
+
+LiXee Zigbee OTA firmware images are made publicly available by Fairecasoimeme / ZiGate (first-party) at the following URL:
+
+https://github.com/fairecasoimeme/Zlinky_TIC/releases
+
+### SALUS/Computime
+
+SALUS/Computime Hue Zigbee OTA firmware images are made publicly available by SALUS (first-party) at the following URL:
+
+https://eu.salusconnect.io/demo/default/status/firmware
+
+### Sengled
+
+Sengled Zigbee OTA firmware images are made publicly available by Dresden Elektronik (third-party) at the following URL:
+
+https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/OTA-Image-Types---Firmware-versions#sengled
+
+### Philips Hue (Signify)
+
+Philips Hue (Signify) Zigbee OTA firmware images are made publicly available by Dresden Elektronik (third-party) at the following URL:
+
+https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/OTA-Image-Types---Firmware-versions#philips-hue
+
+### Ubisys
+
+Ubisys Zigbee OTA firmware images are made publicly available by Ubisys (first-party) at the following URL:
+
+https://www.ubisys.de/en/support/firmware/


### PR DESCRIPTION
Create OTA_URLs.md to collect external URLs for official and third-party Zigbee OTA providers for firmware images.