### PR TITLE
Add lixee (third party link)

### DIFF
--- a/index.json
+++ b/index.json
@@ -1636,7 +1636,7 @@
         "manufacturerCode": 4151,
         "imageType": 1,
         "sha512": "692417e8863827f120cda063850aee65b7b6eb58109d419ff58dced1d7c9251617312368bda0f8488aa26aeb7a8e3642339c7648af24cbff66b870401c9113da",
-        "url": "https://github.com/Koenkk/zigbee-OTA/raw/master/images/Eurotronic/ZLinky_router_v5.0.ota",
+        "url": "https://github.com/fairecasoimeme/Zlinky_TIC/releases/download/v5.0/ZLinky_router_v5.0.ota",
         "path": "images/Eurotronic/ZLinky_router_v5.0.ota"
     },
     {

--- a/index.json
+++ b/index.json
@@ -1636,8 +1636,7 @@
         "manufacturerCode": 4151,
         "imageType": 1,
         "sha512": "692417e8863827f120cda063850aee65b7b6eb58109d419ff58dced1d7c9251617312368bda0f8488aa26aeb7a8e3642339c7648af24cbff66b870401c9113da",
-        "url": "https://github.com/fairecasoimeme/Zlinky_TIC/releases/download/v5.0/ZLinky_router_v5.0.ota",
-        "path": "images/Eurotronic/ZLinky_router_v5.0.ota"
+        "url": "https://github.com/fairecasoimeme/Zlinky_TIC/releases/download/v5.0/ZLinky_router_v5.0.ota"
     },
     {
         "fileVersion": 33555200,


### PR DESCRIPTION
Earlier push included a local path to ZLinky due to tests for #114 .
Corrected this by adding link and removing path (manually, add.js doesn not remove the path).