### PR TITLE
index.json: remove problematic firmware

### DIFF
--- a/index.json
+++ b/index.json
@@ -865,18 +865,6 @@
         "path": "images/Tuya/1615190575-si32_zg_uart_connect_sleep_ZS5_ty_OTA_1.1.7.bin"
     },
     {
-        "fileVersion": 204,
-        "fileSize": 49032,
-        "manufacturerCode": 4098,
-        "manufacturerName": [
-            "_TZE200_hue3yfsn"
-        ],
-        "imageType": 5634,
-        "sha512": "dae622ddfb009cc189e54629b3df47292b3d5555512cb9e9cf5bb9a66fe95e595f1abcdb1a3349deb914fb0ed59453941d448ea63067750a7269b44db9825764",
-        "url": "https://images.tuyaeu.com/smart/firmware/upgrade/ay156144560900410bUk/164155152229641863dfc.bin",
-        "path": "images/Tuya/TV02-Zigbee_MCU_Module_2.0.4_164155152229641863dfc.bin"
-    },
-    {
         "fileVersion": 57,
         "fileSize": 155646,
         "manufacturerCode": 4098,


### PR DESCRIPTION
Upstream issues 104 through 107 cause problems.  Drop the firmware involved.

Confirmed by reproducing https://github.com/Koenkk/zigbee-OTA/issues/104#issuecomment-1094282655 on current master, and that this patch fixes it.