### PR TITLE
Add _TZE200_cpmgn2cf TRV to OTA

### DIFF
--- a/index.json
+++ b/index.json
@@ -883,7 +883,8 @@
         "manufacturerName": [
             "_TZE200_ckud7u2l",
             "_TZE200_cwnjrr72",
-            "_TZE200_ywdxldoj"
+            "_TZE200_ywdxldoj",
+            "_TZE200_cpmgn2cf"
         ],
         "imageType": 5634,
         "sha512": "1113486a67403d922fc4a462b7477e0a0986fa8862a89b74ab8c5eac7b4ecb31c30f1da9ae1bbc1d6d50ae1fed66d38c37a1834ab71fd384c0555002783aba13",


### PR DESCRIPTION
TRV _TZE200_cpmgn2cf works fine with firmware `images/Tuya/1615190575-si32_zg_uart_connect_sleep_ZS5_ty_OTA_1.1.7.bin` so it can be added