### PR TITLE
Update Ubisys range to new firmwares - ubisys Zigbee Stack 4.0.3

### DIFF
--- a/index.json
+++ b/index.json
@@ -1664,12 +1664,12 @@
         "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B39-0000-0004-02000300-spo-fmi4.ota.zigbee"
     },
     {
-        "fileVersion": 33620736,
-        "fileSize": 145662,
+        "fileVersion": 34604035,
+        "fileSize": 149246,
         "manufacturerCode": 4338,
         "imageType": 31537,
-        "sha512": "d60a5c040d80392a241df1b91aac78071ba636e12b17c172d5c33e54765185db6907d40f22a63ae367bdb7fd6fda69b8f8763ff39dd8561652f4237a7ee2762a",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B31-0000-0006-02010300-spo-fmd.ota.zigbee"
+        "sha512": "64b5827c739845812f1e698a8951c6ffcbe692705ace20fdd8e29c0ab3243ac579b9af0eacee1e768932c7f48761c24a5bc65b6d410bc908b284b25cc016b9f1",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B31-0000-0006-02100403-spo-fmd.ota.zigbee"
     },
     {
         "fileVersion": 33620736,

--- a/index.json
+++ b/index.json
@@ -1656,12 +1656,12 @@
         "url": "https://github.com/fairecasoimeme/Zlinky_TIC/releases/download/v12.0/ZLinky_router_v12.ota"
     },
     {
-        "fileVersion": 33555200,
-        "fileSize": 121086,
+        "fileVersion": 34669571,
+        "fileSize": 124414,
         "manufacturerCode": 4338,
         "imageType": 31545,
-        "sha512": "65176b191a5c934be2526fe9307d25fc75b7a93a3ded40f8410f47fbcc0ae5d0e6bdbbf2f9df898898f4c4e75946512127f41b514c5e16029fc7bc993be4060d",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B39-0000-0004-02000300-spo-fmi4.ota.zigbee"
+        "sha512": "ffe1dfba9733a742ccb50e6f7baad42543611d5c713c37d36bf22bef7abd1844c7090f6dfb55eab200134e3e11b2494c8e69ac5a7bcae8457821b6efe34b0e46",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B39-0000-0004-02110403-spo-fmi4.ota.zigbee"
     },
     {
         "fileVersion": 34604035,
@@ -1672,92 +1672,92 @@
         "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B31-0000-0006-02100403-spo-fmd.ota.zigbee"
     },
     {
-        "fileVersion": 33620736,
-        "fileSize": 145662,
+        "fileVersion": 34604035,
+        "fileSize": 148990,
         "manufacturerCode": 4338,
         "imageType": 31544,
-        "sha512": "c0dec27a23ec2c76adce316ffd0eb51ef07f2ef6e249dfff809c2e9acc6c38228ef22b2b8b16d229f0ff0cb8fa1c25dde9ccac22471a906f06c82fe7a0ac9eb6",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B38-0000-0004-02010300-spo-rmd.ota.zigbee"
+        "sha512": "5c4aaebb68af6fd9eb1c8e88d1e92504763717dc4dac758733ee55b4c296d3b1b5efb16b3245120c9343a3dd001fbe3f6f61e80a5619064e872b21a6b68b7168",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B38-0000-0004-02100403-spo-rmd.ota.zigbee"
     },
     {
-        "fileVersion": 33555200,
-        "fileSize": 143870,
+        "fileVersion": 34604035,
+        "fileSize": 147198,
         "manufacturerCode": 4338,
         "imageType": 31540,
-        "sha512": "8b7730e291f20573b2d2c00ec1862a905c5a4d53d0db27710895ad77624fa624cc9e541948a71ab87f9c738cdbf0585f756e52e224748808f3636ca4549aeb1d",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B34-0000-0007-02000300-spo-fmsh.ota.zigbee"
+        "sha512": "fc6efdaeea170b974b2c0243eef417df6eb37de8d1f97b1fdd4792b1f4f85384d7d1f1e8b9c9fb81f2a429fbdbe3392b127db7fd58b9de2969a5ac87030bc989",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B34-0000-0007-02100403-spo-fmsh.ota.zigbee"
     },
     {
-        "fileVersion": 33555200,
-        "fileSize": 143870,
+        "fileVersion": 34604035,
+        "fileSize": 147198,
         "manufacturerCode": 4338,
         "imageType": 31543,
-        "sha512": "301bd6c9ed976b368db7267f737ff9ab32f1d861e5fdd36bb342763272854f3cb4c3436c89e14cc6563e2b2d0f6329c04975043b18fed7d71dff6add0291cbe8",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B37-0000-0004-02000300-spo-rmsh.ota.zigbee"
+        "sha512": "f5d641c24ddbbd50b5ae1abf89c89048d1420ef4c6dccdf6a7491767ac49d2806f741fcd0755fdd75371e00fa37229555be16269bf71f86b9decc7323cf0e2b2",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B37-0000-0004-02100403-spo-rmsh.ota.zigbee"
     },
     {
-        "fileVersion": 33686272,
-        "fileSize": 116222,
+        "fileVersion": 34604035,
+        "fileSize": 119550,
         "manufacturerCode": 4338,
         "imageType": 31546,
-        "sha512": "fa0cced6c5f003601885ff104f9e7306a642083c089a89c00eb7e4f1bafb738608fa2907b1cf6c62f611e9c5df058c2d6bf1b93eca8079443d9e12570ab20bb7",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B3A-0000-0005-02020300-m7b-r0.ota.zigbee"
+        "sha512": "69d1b747b1b3a3694e40f6e6f765c8f7e49e6b5cf4073a553e136fe118be3945bea448709dd199b0a82496e9f5506ed5cd239a13fef7ec490f27e341e9d79567",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B3A-0000-0005-02100403-m7b-r0.ota.zigbee"
     },
     {
-        "fileVersion": 33555200,
-        "fileSize": 141566,
+        "fileVersion": 34669571,
+        "fileSize": 144894,
         "manufacturerCode": 4338,
         "imageType": 31538,
-        "sha512": "27cdc8a0011a73790306a1a484974f7dfe3c12ee91964a0b31534827864e52b61f8b4987a1c0c590fba2b7f4aa039d01cdca1e899a15cf93e178ce38230eef8e",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B32-0002-0007-02000300-spo-fms.ota.zigbee"
+        "sha512": "36f44930d8648994e34da91d797c03cf82bc2cd5cfe86120f8c7d65e09f5eb4cd2f016f71e2376d09544407e947b97f4dfdda21e6d4cf74d179311358ba3b192",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B32-0002-0007-02110403-spo-fms.ota.zigbee"
     },
     {
-        "fileVersion": 33555200,
-        "fileSize": 141566,
+        "fileVersion": 34669571,
+        "fileSize": 144894,
         "manufacturerCode": 4338,
         "imageType": 31541,
-        "sha512": "a4393cac18523c75c0c1621ce7b113d82bd81d5308044fe843b2f7d6e876d1440ac9154590c720ae0673b7feb2fc1202dfa75f11ea4cb4088d3956ae7af8ad50",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B35-0000-0004-02000300-spo-rms.ota.zigbee"
+        "sha512": "c15220e7a3e968bef05389a775b5955c4c71d6a1bb37ed7d97cc36f27e64e555692346aa992cf5063813aca7be9282debf2e3d2ee81d4e5da5e2e2401eccad20",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B35-0000-0004-02110403-spo-rms.ota.zigbee"
     },
     {
-        "fileVersion": 33555200,
-        "fileSize": 141310,
+        "fileVersion": 34669571,
+        "fileSize": 144894,
         "manufacturerCode": 4338,
         "imageType": 31539,
-        "sha512": "591f79fbe2a3b1c735b6e5a232feb73e780b059b6d22bd9a4e0a728f5bd73b72be5358432ee93de28dca6819c2ff590de89ee9319a3d4e83e3869ea33b4f9055",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B33-0000-0006-02000300-spo-fms2.ota.zigbee"
+        "sha512": "da494d1d101a98e7e3984de4ce69ced45c8001f73da734dc20da396568fbed0c68911a0829edd07cac0e1eb25be1d09313c048c8d0903c97f786c7c9fa490d83",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B33-0000-0006-02110403-spo-fms2.ota.zigbee"
     },
     {
-        "fileVersion": 33555200,
-        "fileSize": 141310,
+        "fileVersion": 34669571,
+        "fileSize": 144894,
         "manufacturerCode": 4338,
         "imageType": 31542,
-        "sha512": "e0409ed8e5e990ef1a1ce3b325ef1ed1d09c5bac9c59d9d08613656b0ada307b97c0e4be34e94bcb0c022c9a7b017e62da7bd1a59b6198ac37ee91125f20ca2c",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B36-0000-0004-02000300-spo-rms2.ota.zigbee"
+        "sha512": "9ffe692bd67b9a093c46b569dd34eeeda2682852d3a5e7836b5c1e7cd1abec2fba74b85c9d6e7c07dafb267ec50b975631dc77a57fdd45ce63c544ef8ed74215",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B36-0000-0004-02110403-spo-rms2.ota.zigbee"
     },
     {
-        "fileVersion": 33555200,
-        "fileSize": 149246,
+        "fileVersion": 34604035,
+        "fileSize": 153342,
         "manufacturerCode": 4338,
         "imageType": 31547,
-        "sha512": "ccc153ea31a14dffd1ad5924bb28a6e6d116e4b986e02339a107cf88d6b41e329c615487d26d0d1770c50751e13b5d76f8b504af691039716fe723fc0f8f5d83",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B3B-0000-0001-02000300-m7b-h10.ota.zigbee"
+        "sha512": "762f0f0ad9f82b57ce4670a3032a3d9ff70e4a9710cd027ee99568ef71323384e75b2095875c7eab5a29c175b0b92fbadb7c7b3a7fe97c52195cdd5cea2e9c95",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B3B-0000-0001-02100403-m7b-h10.ota.zigbee"
     },
     {
-        "fileVersion": 16843520,
-        "fileSize": 186366,
+        "fileVersion": 17892352,
+        "fileSize": 236030,
         "manufacturerCode": 4338,
         "imageType": 31532,
-        "sha512": "d771a000a594c186f6fc5957070246267e76c44bd2696e4b47eb8dbc89fa8fba95747eb04941df35d73ab017eb929c3a79091d6cdf0c7cc1d12580318f6a3309",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B2C-0000-0001-01010300-ld6.ota.zigbee"
+        "sha512": "b68da7ad070e737721b3a7914991a1d09a2909bbbb5e788ce8e1468509994d6fd0cdad6c029c1ca654be16f58a8c0d27d5df1f2914ddd522c006d95327a07b5c",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B2C-0000-0001-01110400-ld6.ota.zigbee"
     },
     {
-        "fileVersion": 18612992,
-        "fileSize": 171518,
+        "fileVersion": 18875395,
+        "fileSize": 175102,
         "manufacturerCode": 4338,
         "imageType": 31501,
-        "sha512": "4c025450a7ee6e7102b7b42a4e82163be44eeb731757959e28bed550bcc5f9dbeaab819dab37d7d815766a0bbc5b78de1986892cdf13b134ac7f2bd6dcdf72b8",
-        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B0D-0000-0001-011C0300-m7b-h1.ota.zigbee"
+        "sha512": "4a65ce37de9c0f8163e4cd5da9423dd1fd81d6ae4dd26afc6dcadd92eba694ea37caece45a32ed393e2588e4392719b39755c5a06689125d32921be4f7e493f4",
+        "url": "https://www.ubisys.de/wp-content/uploads/10F2-7B0D-0000-0001-01200403-m7b-h1.ota.zigbee"
     },
     {
         "fileVersion": 352399361,


### PR DESCRIPTION
New firmware for the D1 dimmer was released 25.01.23

Changelog here:
https://www.ubisys.de/en/support/firmware/changelog-d1/