### PR TITLE
Updated Hue images

### DIFF
--- a/index.json
+++ b/index.json
@@ -299,12 +299,12 @@
         "url": "https://otau.meethue.com/storage/ZGB_100B_011D/466ea3c4-5a8f-453e-adc0-870bb777f076/100B-011D-01002102-ConfLight-ModuLumV2-EFR32MG13.zigbee"
     },
     {
-        "fileVersion": 16785666,
-        "fileSize": 445838,
+        "fileVersion": 16785668,
+        "fileSize": 445682,
         "manufacturerCode": 4107,
         "imageType": 286,
-        "sha512": "cc02e793fc2e22558f374fbf9786731747b8537694c72e54b5a9d31a853d170025586c14c1a1d89e76e64358d9b9bce0748f171c7585d10952f1248cb83c0b6f",
-        "url": "https://otau.meethue.com/storage/ZGB_100B_011E/83674003-b78b-471b-80cf-0ce580077378/100B-011E-01002102-ConfLight-PortableV2-EFR32MG13.zigbee"
+        "sha512": "5529e417ffe7353ed33dfebb514305f589096912bbda735f2a20349af7548851664221611e485e587d4c58faa81a55454d55af47296cdd2dd2be84176f5d7320",
+        "url": "https://otau.meethue.com/storage/ZGB_100B_011E/24e32bcb-09d2-4370-a314-1795f6e483f7/100B-011E-01002104-ConfLight-PortableV2-EFR32MG13.zigbee"
     },
     {
         "fileVersion": 16785410,
@@ -315,12 +315,12 @@
         "url": "https://otau.meethue.com/storage/ZGB_100B_011F/c6193212-2531-4346-ad96-c5d48963ce9c/100B-011F-01002002-ConfLightBLE-ModuLumV3-EFR32MG21.zigbee"
     },
     {
-        "fileVersion": 16785410,
+        "fileVersion": 16785412,
         "fileSize": 386628,
         "manufacturerCode": 4107,
         "imageType": 288,
-        "sha512": "3f4704f3d5ef1bf7542f75e9dda2763f2d76eb9b6f46516ee75cc17f47f5c4012c77b8cfa4e56fb00867e4c98937221f7b51736fb0557308cf550c5d6635089f",
-        "url": "https://otau.meethue.com/storage/ZGB_100B_0120/85a46316-db06-48c5-ac7d-e43c315bf743/100B-0120-01002002-ConfLightBLE-PortableV3-EFR32MG21.zigbee"
+        "sha512": "5271ae1d93219ae3570f4bd471b13ab9316e27222fedef827a3a7fa22f6fbcb9625f795557884ca5abd004f78e1bedba09a9f85b53346262ec65a02aadfd9375",
+        "url": "https://otau.meethue.com/storage/ZGB_100B_0120/aa33cf16-f9a8-4675-893c-056aaadad01d/100B-0120-01002004-ConfLightBLE-PortableV3-EFR32MG21.zigbee"
     },
     {
         "fileVersion": 3080,


### PR DESCRIPTION
1.104.3 for hardware version 100B-11E and 100B-120 (portable Hue lights).
Release notes: https://www.philips-hue.com/en-us/support/release-notes/lamps