### PR TITLE
Update index.json to support _TZE200_kds0pmmv variant of TV02 thermostat from Moes

### DIFF
--- a/index.json
+++ b/index.json
@@ -891,6 +891,7 @@
         "fileSize": 234174,
         "manufacturerCode": 4098,
         "manufacturerName": [
+            "_TZE200_kds0pmmv",
             "_TZE200_ckud7u2l",
             "_TZE200_cwnjrr72",
             "_TZE200_ywdxldoj",


### PR DESCRIPTION
Add _TZE200_kds0pmmv variant of TV02 from Moes.
I tested it on 2 devices i own.