### PR TITLE
Add new firmware v1.1.0 for TS011F/_TZ3000_fukaa7nc

### DIFF
--- a/index.json
+++ b/index.json
@@ -1591,7 +1591,8 @@
         "manufacturerCode": 4417,
         "manufacturerName": [
             "_TZ3000_w0qqde0g",
-            "_TZ3000_dksbtrzs"
+            "_TZ3000_dksbtrzs",
+            "_TZ3000_fukaa7nc"
         ],
         "imageType": 54179,
         "sha512": "c541878e792620ad16cc70967e0458c03de21876ad8ed3c3b1eb90c8ecf7bcdfe6bfe711460a5888bb033def141e7dd22d78fe24c44a4e0b9707afb473a2d2a2",


### PR DESCRIPTION
Downgrading from v3.0.0 to v1.1.0 seems to fix random turnoff when plug detects under voltage.

Plug reports under voltage, but doesn't turnoff.