### PR TITLE
Run auto download daily for specific manufacturers

### DIFF
--- a/.github/workflows/run_autodl_daily.yml
+++ b/.github/workflows/run_autodl_daily.yml
@@ -1,0 +1,51 @@
+name: Run auto download
+on:
+    schedule:
+        - cron: '0 0 * * *'
+
+env:
+    # comma separate values, no spaces
+    MANUFACTURERS_TO_PROCESS: "inovelli"
+
+permissions:
+    contents: write
+
+jobs:
+    run-autodl:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: pnpm/action-setup@v4
+              with:
+                  version: 9
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  registry-url: https://registry.npmjs.org/
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm i --frozen-lockfile
+
+            - name: Build
+              run: pnpm run build
+
+            - name: Run Autodl
+              uses: actions/github-script@v7
+              env:
+                  NODE_EXTRA_CA_CERTS: cacerts.pem
+              with:
+                  script: |
+                      const {runAutodl} = await import("${{ github.workspace }}/dist/ghw_run_autodl.js")
+
+                      await runAutodl(github, core, context, "$MANUFACTURERS_TO_PROCESS")
+
+            - name: Commit changes
+              run: |
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                  git add .
+                  git commit -m "Autodl update" || echo 'Nothing to commit'
+                  git push

--- a/.github/workflows/run_autodl_daily.yml
+++ b/.github/workflows/run_autodl_daily.yml
@@ -1,7 +1,7 @@
-name: Run auto download
+name: Run daily auto download
 on:
     schedule:
-        - cron: '0 0 * * *'
+        - cron: '0 12 * * *'
 
 env:
     # comma separate values, no spaces
@@ -47,5 +47,5 @@ jobs:
                   git config --global user.name 'github-actions[bot]'
                   git config --global user.email 'github-actions[bot]@users.noreply.github.com'
                   git add .
-                  git commit -m "Autodl update" || echo 'Nothing to commit'
+                  git commit -m "Daily autodl update" || echo 'Nothing to commit'
                   git push


### PR DESCRIPTION
As discussed with @Nerivec in the context of #697, a lot of manufacturers have extensive rate limiting on their API endpoints. For manufacturers that specifically request their OTAs being processed more frequently, we can run a custom job for this one.

Added a new action that will run daily and has an environment variable to populate the list of manufacturers. It intentionally does not trigger a release (keeping that for the weekly job)

Fixes: #697