### PR TITLE
feat: keep records of identifiable stacks for firmware files

### DIFF
--- a/.github/workflows/run_autodl.yml
+++ b/.github/workflows/run_autodl.yml
@@ -55,6 +55,10 @@ jobs:
 
                       await runAutodl(github, core, context, "${{ inputs.manufacturers || '' }}")
 
+                      const {identifyStacks} = await import("${{ github.workspace }}/dist/ghw_identify_stacks.js")
+
+                      identifyStacks(github, core, context)
+
             - name: Create Autodl release
               uses: actions/github-script@v7
               with:

--- a/biome.json
+++ b/biome.json
@@ -10,6 +10,7 @@
     "files": {
         "ignore": [
             "package.json",
+            "./index-stackinfo.json",
             "./index.json",
             "./index1.json",
             "./.cache",

--- a/index-stackinfo.json
+++ b/index-stackinfo.json
@@ -1,0 +1,4130 @@
+[
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Aurora/MainsPowerOutlet_JN5169_PCB_ARC_OTA_0x1409_v22.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Bosch/0x1209_0x300e_0x02086a30.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Bosch/0x1209_0x3011_0x03076a30.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Bosch/ota_t0x3002_m0x1209_v0x2a006a30.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Bosch/ota_t0x300a_m0x1209_v0x37041514.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ClimaxTechnology/12128_OTA_3.18.ZIGBEE",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ClimaxTechnology/PRS3CH1_00.00.05.11TC.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ClimaxTechnology/PRS3CH2_00.00.05.12TC.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/DIY/db15-0203-11003001-z03mmc.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Danalock/115C-0004-11040000-ZigbeeXM_101-029_E1_DanalockV3_17.4.0_20221213143911.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Danalock/115C-0004-11070000-ZigbeeXM_101-029_E1_DanalockV3_17.7.0_20240201155008.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Danfoss/PSoC4_1246-0100-01280128.0002_(4CA01CD1).ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Danfoss/PSoC6_1246-0120-00280028.0002_(90215AC0).ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Datek/ctm_mains_power_outlet.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Datek/ctm_mbd-s_2_5.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Datek/dimmerpille_v2_0_v_4_combined_OTA.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Datek/eva_meter_reader-2.0_MG21.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Datek/han_adapter-0.7_MG13_nonreworked.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Datek/han_adapter-2.0_MG13_reworked.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Datek/mTouch_Dim_v3_1_v35_combined_OTA.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Datek/mTouch_One_v3_8_v72_combined_OTA.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Datek/mains_power_outlet_2.7.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/ED%20-%20HA%20-%20VOC%20Sensor-SSIG%204.0.1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/EMI2LED_3.1.2.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/EMI2P1_3.1.7.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/EmiNorwegianHan_4.0.7.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/EntrySensor2_2.0.6.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/EntrySensor_4.0.2.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/HumiditySensor_4.0.1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/IntelligentKeyPad_2.0.5.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/MotionSensor2_2.0.6.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/MotionSensor_4.0.6.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/SmartButton_2.0.2.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/SmartPlug2_2.0.5.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/WaterLeakDetector_4.0.4.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/ZR_Smartplug_SSIG_3.12.16.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/ZigbeeRangeExtender_2.0.2.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/DresdenElektronik/1135-0000-201000F5-FLS-PP3_RGBW_16Mhz.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/DresdenElektronik/1135-0100-1000002A-Kobold.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/DresdenElektronik/1135-0101-0020001B-Hive.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/EcoDim/ZB21S3_HZC_Dimmer1_EcoDim-Zigbee%203.0_1.01_20230908.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/GammaTroniques/TICMeter.ota",
+    "stack": "ZBOSS",
+    "stackDetails": "Nordic (fuzzy matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-B-007P_V17_OTAV7_20210305_100%25.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-B-007P_V20451233_20240425.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-B-008P_V17A1_OTAV7.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-C-008P_V17A1_OTAV7_20210303--V1-4.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-D-004P_V105_20220427(1).ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-D-005P_V11076801_OTAV12_20211108_60%25.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-D-006P_V105_20220511.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-D-007P.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-D-007P_V105_20220418(1).ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-FL-005P_V14_OTAV4_20210119_100%25.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-FL-006P_V14_OTAV4_20210119_100%25.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-G-001P_V11076801_OTAV12_20211028.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-S-006P_V107_20220906.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Gledopto/GL-S-007P_V15_A1_OTAV5_20210201_90%25.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-010C-01001A02-ConfLight-Lamps_0012.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-010C-01002800-ConfLight-Lamps_0012.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-010E-01001904-ConfLight-ModuLum_0012.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-010E-01002600-ConfLight-ModuLum_0012.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-010F-01000A02-ConfLight-LedStrips_0012.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-010F-01001700-ConfLight-LedStrips_0012.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0110-01000400-ConfLight-Lamps-EFR32MG13_0012_inclBL.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0110-01002602-ConfLight-Lamps-EFR32MG13.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0111-01001D00-ConfLight-ModuLum-EFR32MG13.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0112-01002902-ConfLightBLE-Lamps-EFR32MG13.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0114-01001200-ConfLightBLE-Lamps-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0114-01001300-ConfLightBLE-Lamps-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0114-01001304-ConfLightBLE-Lamps-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0114-01002502-ConfLightBLE-Lamps-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0115-01001402-SmartPlug-EFR32MG13.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0116-02001300-Switch-EFR32MG13.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0116-02004D27-Switch-EFR32MG13.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0117-01000B00-ConfLightBLE-ModuLum-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0117-01000C00-ConfLightBLE-ModuLum-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0117-01000C04-ConfLightBLE-ModuLum-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0117-01001D0C-ConfLightBLE-ModuLum-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0118-01001802-PixelLum-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0119-02002100-Switch-EFR32MG22.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0119-02004D27-Switch-EFR32MG22.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-011A-01000400-SmartPlug-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-011A-01000500-SmartPlug-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-011A-01000504-SmartPlug-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-011A-01000F04-SmartPlug-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-011B-02004D23-Sensor-EFR32MG22.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-011C-02004D23-SwitchModule-EFR32MG13.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-011D-01002504-ConfLight-ModuLumV2-EFR32MG13.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-011E-01002404-ConfLight-PortableV2-EFR32MG13.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-011F-01002402-ConfLightBLE-ModuLumV3-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0120-01002402-ConfLightBLE-PortableV3-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0121-02004D27-Switch-EFR32MG22-40xf.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0122-02004D23-SwitchModule-EFR32MG22.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0123-01000C02-PixelLumXL-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0125-02004301-ContactSensor-EFR32MG22.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0125-02004D23-ContactSensor-EFR32MG22.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0127-01000D02-MSD-EFR32MG21.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/ConnectedLamp-Atmel-Target_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/ConnectedLamp-Atmel_0104_5.130.1.30000_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/ConnectedLamp-TI-Target_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/LivingColors-Atmel-Target_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/LivingColors-Hue-Target_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/LivingColors-Target_0108_5.130.1.30000_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/ModuLum-ATmega_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/ModuLum-ATmega_010B_5.130.1.30000_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/Sensor-ATmega_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/Superman_v3_08_ProdKey_3080.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/Switch-ATmega_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/WhiteLamp-Atmel-Target_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/WhiteLamp-Atmel-Target_0105_5.130.1.30000_0012.sbl-ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/10035515-TRADFRI-bulb-cws-2.3.093.ota.ota.signed",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/10082264-zingo_lds_stoftmoln-1.1.7.ota.ota.signed",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/inspelning-smart-plug-soc_release_prod_v33816645_02579ff4-6fec-42f6-8957-4048def87def.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/mgm210l-light-cws-cv-rgbw_release_prod_v268572245_3ae78af7-14fd-44df-bca2-6d366f2e9d02.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/motionsensor-lds-mg21a_release_prod_v16777316_3a00064a-cc29-4aac-bdb6-c4fa1fb445d5.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/ota_t0x110e_m0x117c_v0x01000035.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/ota_t0x110f_m0x117c_v0x01000011.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/rodret-dimmer-soc_release_prod_v16777303_0a78457a-950c-4903-bfd1-67902aa66cf9.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/rodret-shortcut-soc_release_prod_v16777249_d89ffc33-55d1-4d47-acac-42365e5d9dd8.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-bulb-cws-zll_release_prod_v587753009_ec8b1193-0fa2-440e-b921-2412a8688b74.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-bulb-w-1000lm_release_prod_v587810353_5a161508-742d-4eab-8761-286c80d116eb.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-bulb-ws-1000lm_release_prod_v587814449_2b13625e-17a8-40d9-bad3-47a9a96ab002.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-bulb-ws-e14_release_prod_v587757105_963ac72a-97be-4f7e-b12c-46759bb91d6e.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-bulb-ws-gu10_release_prod_v587757105_25ac125d-5723-4b92-aa02-404fd5008a55.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-connected-blind_release_prod_v604241939_89e61475-8999-4074-842a-e04efac9c857.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-control-outlet_release_prod_v587765297_20061876-85d6-4b39-8c9c-eb95620baa97.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-controller_release_prod_v604241925_abef4451-762a-4ef9-8c11-dfd88c3e98f7.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-cv-cct-unified_release_prod_v587757105_33e34452-9267-4665-bc5a-844c8f61f063.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-dimmer_release_prod_v604241925_ecbb4451-ce85-4e6c-ab9f-e7ce32cd0c1e.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-driver-hp_release_prod_v587757105_b42c57bf-cb9c-478c-8327-5812a3286a64.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-driver-lp_release_prod_v587757105_b28cda41-22d2-446b-b3bf-5ca11d866719.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-driver-zingo_release_prod_v16777220_1fd2b92c-45c5-44d0-97c5-5c71c2ecb8d2.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-light-unified-w_release_prod_v587806257_147c8812-e7f3-4999-b7eb-3da91009ab65.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-motion-sensor2_release_prod_v604241925_8afa2f7c-19c3-4ddf-a96c-233714179022.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-onoff-controller_release_prod_v604241926_3c2e5569-667c-49ed-a286-78a0e031935d.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-shortcut-button_release_prod_v604241926_56f5d8d1-78b1-4088-afc1-05d3b7e3314b.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-signal-repeater_release_prod_v587753009_3ce8f096-bd12-4b2c-b66e-51dc9f2637dc.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-sy5882-bulb-ws_release_prod_v587814449_185b3c4d-da1b-4867-8c16-2cee1fc5c11d.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-sy5882-driver-ws_release_prod_v587798065_479fc716-673b-4731-bbb7-86833c456e4c.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-sy5882-unified_release_prod_v587757105_d478807c-f16e-4989-a948-82818fb545b9.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-transformer_release_prod_v587753009_17d32c23-151f-44cb-a947-4c13a78f36e6.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tradfri-wireless-dimmer_release_prod_v587367985_87ff9a75-c4e3-4999-a654-09bb8638f4cc.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/tretakt_smart_plug_soc-0x1100-2.4.25-prod.ota.ota.signed",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-jetstrom-cws_release_prod_v16777268_023f19b9-f55b-4c94-a3fe-00c97755eb78.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-jetstrom-ws_release_prod_v33816584_33813e5d-0cc9-4b4a-9e93-9000ee44cbe4.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-kt-bulb-hwpwmcs-ws_release_prod_v16842784_32dc5ff1-4fa4-4960-a847-5e548a81047c.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-kt-styrbar-remote_release_prod_v33816598_c00d5422-e816-48ec-87a6-40198661d2d5.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-lds-bulb-hwpwm-ww_release_prod_v16842756_529d7965-cee3-4c32-bd28-e5dd17ddc256.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-lds-bulb-hwpwmcs-ws_release_prod_v65554_5d50205c-63c3-426d-bfba-4839c4b55bba.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-lds-plugin-unit_release_prod_v65538_b29c3768-a102-4414-a84d-405c99654e74.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-lds-starkvind_release_prod_v69633_2044addf-0a35-4845-b851-74df04ab3a76.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-sigma-driver-silverglans-ww_release_prod_v65569_73466dc4-1320-4242-add6-717432538a77.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-ws-soc_release_prod_v50331683_f909cf22-3452-47e3-b8b2-c59d82102e17.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-ws_release_prod_v50331681_969bee21-eca6-4f10-a4c0-9685c0cd5d52.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo-ww_release_prod_v16777282_a39f1e76-af87-4f04-bd7f-0faf71baf3e4.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/IKEA/zingo_cws-0x2805-1.0.44-prod.ota.ota.signed",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0109-17103685-rb262-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-010a-17103685-rb267-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-010b-17103685-rb243-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-010d-17103685-rf262-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0112-10096610-RS_226v1-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0115-20046A30-RS_230_C-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-011A-20086A30-RS_229_T-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-011B-10116610-RB_245_v2-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-011C-20026A30-RB_248_T_v2-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0120-20026A30-RF_263-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0121-20026A30-RF_265-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0122-20026A30-RF_261-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0124-20046A30-RF_264-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0128-24031511-upgradeMe-RS%20226.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0129-24031511-upgradeMe-RS%20227%20T.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-012A-24031511-upgradeMe-RB%20245.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-012B-24031511-upgradeMe-RB%20249%20T.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-012C-24031511-upgradeMe-RB%20251%20C.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-012D-24031511-upgradeMe-RB%20266.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-012E-24031511-upgradeMe-RB%20279%20T.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-012F-24021511-upgradeMe%20-RB%20286%20C.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0130-22151511-upgradeMe%20%20RS%20232%20C%2020230714.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0131-24081511-upgradeMe%20%20RB%20255%20C%2020230714.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0132-17103685-rb272t-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0133-17103685-rb247t-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0134-17103685-rf273t-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0135-17103685-rf274t-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0136-17103685-rf271t-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0209-17103685-bb262-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0220-20026A30-BF_263-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0221-20026A30-BF_265-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-022D-24031511-upgradeMe-BY%20266.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-022F-24021511-upgradeMe%20BY%20286%20C.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0311-27016A30-SP_222-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0312-27016A30-upgradeMe.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0313-31016610-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0401-17103685-ae262-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0402-17103685-ae264-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0414-20026A30-AE_280_C-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0430-17103685-ae270t-1.7.16.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0980-20036A30-RCL_240_T-upgradeMe.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Inovelli/DZM32-SN_1.13.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Inovelli/VZM31-SN_2.18-Production.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Inovelli/VZM35-SN_1.07.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Inovelli/VZM36_1.01-Beta.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Insta/V00.00.52.12.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Insta/ZLL_HS_4f_GJ_Release_10.03.32.02.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Insta/ZLL_WS_4f_J_Release_10.03.32.02.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/20190408_EUROTRONIC_Spirit_Zigbee_0x00122C380.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/BSM300Z_OTA_ENC_V4_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/CSM300Z_TOF_OTA_ENC_V15_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/DIO300Z_OTA_ENC_V5_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/DLM300Z_OTA_ENC_V8_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/DMS300Z_OTA_ENC_V3_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/DSM300Z_OTA_ENC_V5_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/GCM300Z_OTA_ENC_V1_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/ISM300Z_OTA_ENC_V3_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/MSM300Z_OTA_ENC_V4_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/PMM300Z2_OTA_ENC_V6_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/SBM300ZB_OTA_ENC_V4_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/TCM300Z_OTA_ENC_V5_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/TSM300Z_OTA_ENC_V6_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/USM300Z_OTA_ENC_V6_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/JetHome/jethome_zigbee_release_15_zigbee.ota.zigbee",
+    "stack": "zStack",
+    "stackDetails": "CC26x2R1",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/1189_007c_11436630_Release.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/1189_0097_11436630_Release.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/A19_RGBW_IMG0019_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/A19_TW_10_year_IMG000D_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/A19_W_10_year_IMG000C_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/A60S_RGBW-0x1189-0x00A0-0x03197310-MF_DIS-20240523095111-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/A60S_TW-0x1189-0x00A2-0x03177310-MF_DIS-20240426153518-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/A60_DIM_Z3_IM003D_01056400-encrypted_202129091152_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/A60_RGBW_Value_II-0x1189-0x008A-0x03197310-MF_DIS-20240523093911-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/A60_TW_Value_II-0x1189-0x008B-0x03177310-MF_DIS-20240426150951-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/A60_TW_Z3_IM003C_01056400-encrypted_202129091149_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/B40S_TW-0x1189-0x00A3-0x03177310-MF_DIS-20240426154101-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/B40_DIM_Z3_IM0034_01056400-encrypted_202129091146_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/B40_TW_Value-0x1189-0x008C-0x03177310-MF_DIS-20240426151750-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/B40_TW_Z3_IM0033_01056400-encrypted_202129091140_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/BR30_RGBW_IMG001B_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/BR30_TW_IMG001A_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/BR30_W_10_year_IMG000F_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/CLA60_RGBW_Z3_IM0011_01066400-encrypted_202126110358_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Conv_Under_Cabinet_TW_IMG0021_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM-A60_DIM_T-0x00CD-0x03203660.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM-A60_FIL_DIM_T-0x00D0-0x03203660.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM-B40_DIM_T-0x00B8-0x03203660.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM-EDISON60_FIL_DIM_T-0x00D1-0x03203660.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM-GLOBE60_FIL_DIM_T-0x00D2-0x03203660.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM-P40_DIM_T-0x00CE-0x03203660.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM-PAR16_DIM_T-0x00CF-0x03203660.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_ENERGY-TUBE_T8_CON_1200_16W_830ZBVR-0x1189-0x00DE-0x02056550-MF_DIS-20230612083031-322101076832.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_ENERGY-TUBE_T8_CON_1200_16W_840ZBVR-0x1189-0x00C7-0x02056550-MF_DIS-20230612075626-322101076832.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_ENERGY-TUBE_T8_CON_1200_16W_865ZBVR-0x1189-0x00C8-0x02056550-MF_DIS-20230612080310-322101076832.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_ENERGY-TUBE_T8_CON_1500_24W_830ZBVR-0x1189-0x00DD-0x02056550-MF_DIS-20230612083725-322101076832.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_ENERGY-TUBE_T8_CON_1500_24W_840ZBVR-0x1189-0x00C9-0x02056550-MF_DIS-20230612081003-322101076832.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_ENERGY-TUBE_T8_CON_1500_24W_865ZBVR-0x1189-0x00CA-0x02056550-MF_DIS-20230612081654-322101076832.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_ENERGY-TUBE_T8_CON_600_7_5W_830ZBVR-0x1189-0x00DF-0x02056550-MF_DIS-20230704080741-322101076832.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_ENERGY-TUBE_T8_CON_600_7_5W_840ZBVR-0x1189-0x00CB-0x02056550-MF_DIS-20230704075326-322101076832.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_ENERGY-TUBE_T8_CON_600_7_5W_865ZBVR-0x1189-0x00CC-0x02056550-MF_DIS-20230704080035-322101076832.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-DL_PFM155UGR_04-0x1189-0x0087-0x02116550-MF_DIS-20230710044635-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-DL_PFM195UGR_04-0x1189-0x0088-0x02116550-MF_DIS-20230708054143-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-LN_Indivi1200_04-0x1189-0x0084-0x02116550-MF_DIS-20230710043240-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-LN_Indivi1500_04-0x1189-0x0085-0x02116550-MF_DIS-20230708053449-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-PL_DI1200_04-0x1189-0x0086-0x02116550-MF_DIS-20230710043941-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-PL_Indivi600_04-0x1189-0x0082-0x02116550-MF_DIS-20230710041844-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-PL_Indivi625_04-0x1189-0x0083-0x02116550-MF_DIS-20230710042543-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-PL_PFM600UGR_04-0x1189-0x0080-0x02116550-MF_DIS-20230710040457-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-PL_PFM600_04-0x1189-0x0089-0x02116550-MF_DIS-20230710045334-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-PL_PFM625UGR_04-0x1189-0x0081-0x02116550-MF_DIS-20230710041154-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DIM_UART-PL_PFM625_04-0x1189-0x007F-0x02116550-MF_DIS-20230710035807-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/DL_HCL_DN150_01_IM0096_010A6400-encrypted_202331101115_withoutMF.OTA",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Downlight_TW_HCL_IM0065_00103201-encrypted_09_20_2019_Fri_142050_70_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Edge_Lit_Under_Cabinet_IMG0023_00102411-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/FLEX_Outdoor_RGBW_IMG001F_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/FLEX_RGBW_IMG001E_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Flex_RGBW_Z3_IM002A_01066400-encrypted_202216020348_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Flushmount_TW_IMG0022_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Gardenpole_Mini_RGBW_Z3_IM0040_01066400-encrypted_202210011005_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Gardenpole_RGBW_Z3_IM003B_01066400-encrypted_202216020351_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/LEDVANCE_DIM-0x1189-0x006F-0x03177310-MF_DIS-20240428033446-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Outdoor_Accent_Light_RGB_IMG0020_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Outdoor_FLEX_RGBW_Z3_IM005C_01066400-encrypted_202210011002_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/P40S_TW-0x1189-0x00A4-0x03177310-MF_DIS-20240426154635-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/P40_TW_Value-0x1189-0x008D-0x03177310-MF_DIS-20240426152357-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PAR16S_RGBW-0x1189-0x00A6-0x03197310-MF_DIS-20240523095706-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PAR16S_TW-0x1189-0x00A5-0x03177310-MF_DIS-20240426155214-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PAR16_DIM_Z3_IM0031_01056400-encrypted_202129091143_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PAR16_RGBW_Value-0x1189-0x008E-0x03197310-MF_DIS-20240523094504-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PAR16_RGBW_Z3_IM0030_01066400-encrypted_202126110402_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PAR16_TW_Value-0x1189-0x008F-0x03177310-MF_DIS-20240426152944-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PAR16_TW_Z3_IM002E_01056400-encrypted_202129091137_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PAR38_W_10_year_IMG0010_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PLUG_COMPACT_EU_T-0x00D6-0x032B3674-MF_DIS.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PLUG_EU_T-0x00D4-0x032B3674-MF_DIS.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PLUG_OUTDOOR_EU_T-0x00C2-0x032B3674-MF_DIS.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PLUG_UK_T-0x00D5-0x032B3674-MF_DIS.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PL_HCL600_01_IM0095_010A6400-encrypted_202331101118_withoutMF.OTA",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PL_HCL625_01_IM0094_010A6400-encrypted_202331101122_withoutMF.OTA",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Panel_TW_HCL_IM0063_00103201-encrypted_09_18_2019_Wed_113705_07_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Panel_TW_Z3_IM005A_01056400-encrypted_202129091207_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Plug_Value-0x1189-0x0067-0x031F7310-MF_DIS-20240710124454-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Plug_Z3_IM002D_00103101-encrypted_12_07_2018_Fri_103650_94_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/RT_RGBW_IMG001D_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/RT_TW_IMG001C_00102428-encrypted.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/TW_UART_ENERGY-DL_HCL_ND150_02-0x1189-0x00BB-0x02236550-MF_DIS-20230609102634-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/TW_UART_ENERGY-PL_HCL300x1200_01-0x1189-0x00BC-0x02236550-MF_DIS-20230609103517-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/TW_UART_ENERGY-PL_HCL600_02-0x1189-0x00B9-0x02236550-MF_DIS-20230609100910-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/TW_UART_ENERGY-PL_HCL625_02-0x1189-0x00BA-0x02236550-MF_DIS-20230609101747-3221010102432.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Tibea_TW_Z3_IM002C_01056400-encrypted_202129091201_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Undercabinet_TW_Z3_IM0046_01056400-encrypted_202129091204_withoutMF.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/VIVARES_PBC4_01_0X0098_0x10132503.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/Zigbee3toDALI_100E655B.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-000e-004c4203-NLF.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-000f-00414203-NLL.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0010-00434203-NLM.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0011-00654203-NLP.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0012-004e4203-NLT.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0013-003d4203-NLV.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0015-00264203-NLC.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0016-002f4203-NLD.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0018-00204203-NLTS.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0019-00254203-NLFN.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-001c-00214203-NLFE.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-001d-002d4203-NLUI-8090D0-Boot-universal-Switch_2_16.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-001e-002d4203-NLUF-8190D7-Boot-universal-Dimmer_2_23.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-001f-002d4203-NLUP-8080C9-Boot-plug-Switch_2_09.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0020-002d4203-NLUO-8190D7-Boot-universal-Dimmer_2_23.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0024-001a4203-NLIS.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-002a-00184203-NLW.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-002e-001d4203-NLIV.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-002f-00104203-NLH.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0033-000b4203-NLJ.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-0034-00074203-NLY.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LiXee/ZLinky_router_v16.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LiXee/ZLinky_router_v16_limited.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20211122110505_OTA_lumi.curtain.hagl07_V48_20211119_2C5A.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20211124154453_OTA_lumi.switch.n1aeu1_0.0.0_1123_20211110.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20211228121851_OTA_lumi.switch.b1nacn02_0.0.0_0065_20211223_EB5B32.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20211228180917_OTA_lumi.switch.b1naus01_0.0.0_0031_20211228_5689C8.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220104175358_OTA_lumi.plug.maus01_0.0.0_0017_20211224_83991F.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220106191002_OTA_lumi.switch.b2nacn02_0.0.0_0066_20211223_7588AC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220212141304_OTA_lumi.curtain.aq2_0.0.0_0033_20220124_2C69FB.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220222162717_OTA_lumi.light.rgbac1_0.0.0_0028_20220222_BFF63B.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220222202427_OTA_lumi.airmonitor.acn01_0.0.0_0029_20220222_17EC2C.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220316103100_OTA_lumi.curtain.v1_0.0.0_0036_20220125_BEEC32.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220402154955_OTA_lumi.light.aqcn02_0.0.0_34_20220331_2215F2.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220506181329_lumi.curtain.agl001_Multi_JN5189_FMSH_0.0.0_2424_20220422_1aa302.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220524105221_OTA_lumi.motion.ac01_0.0.0_0054_20220509_EB279B.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220607175331_OTA_lumi.switch.acn029_0.0.0_211551_20220217_08B622.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220607175754_OTA_lumi.switch.acn030_0.0.0_211551_20220217_BBD96B.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220607180259_OTA_lumi.switch.acn031_0.0.0_211551_20220217_C7F604.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220607183723_OTA_lumi.remote.cagl02_V1.0.25_20220602_44D1AF.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220701175804_OTA_lumi.switch.b2lc04_0.0.0_0023_20220701_E4CE08.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220701180138_OTA_lumi.switch.b1lc04_0.0.0_0023_20220701_1ED980.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220718113235_OTA_lumi.sensor_smoke.acn03_0.0.0_0017_20220617_CB9276.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220718144406_OTA_lumi.switch.n3acn3_0.0.0_0033_20211108_E03E80.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220728184843_OTA_lumi.ctrl_86plug.aq1_0.0.0_0094_20220722_42FE08.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20220920171525_OTA_lumi.airm.fhac01_0.0.0_0026_20220919_BEDF49.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20221009111923_OTA_lumi.curtain.acn002_0.0.0_1530_20221009_6C9C3D.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20221123140517_OTA_lumi.remote.b1acn02_0.0.0_0031_20221010_8D956D.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20221213122302_OTA_aqara.feeder.acn001_0.0.0_3833_20220914_03DFD1.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230110152017_OTA_lumi.sensor_ht.agl02_0.0.0_0029_20230109_88D8F4.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230110152619_OTA_lumi.magnet.agl02_0.0.0_0030_20230109_D7EBD0.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230112205436_OTA_lumi.motion.agl04_0.0.0_0027_20230109_4D9D5F.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230130180718_OTA_lumi.motion.ac02_0.0.0_0010_20230104_390E3D.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230202185209_OTA_lumi.ctrl_ln2.aq1_0.0.0_0095_20220725_0B0798.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230202185525_OTA_lumi.ctrl_ln1.aq1_0.0.0_0095_20220804_59D5CD.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230209143954_OTA_lumi.motion.agl02_0.0.0_0037_20230209_78D49C.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230221165005_OTA_lumi.airrtc.agl001_0.0.0_1030_20230220_712488.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230425180824_OTA_lumi.sensor_gas.acn02_0.0.0_0017_20230423_3F1EAA.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230610160234_lumi.light.acn132_mcu_0.0.0_2627_20230606_DA1C86.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230704151031_OTA_lumi.curtain.vagl02_V41_20230703_563B.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20230905121119_OTA_lumi.light.acn003_0.0.0_0029_20230712_1D4A6E.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20231222182930_lumi.light.acn128_0.0.0_0022_20231219_46D8F0.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20231222183430_lumi.light.acn014_0.0.0_0040_20231220_1E2291.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20231222194652_lumi.dimmer.acn004_0.0.0_0024_9FD15B.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20231222195203_lumi.light.acn024_0.0.0_0041_20231220_20F906.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20231222195338_lumi.light.acn026_0.0.0_0041_20231220_20F906.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20231227113728_lumi.light.acn031_0.0.0_0026_20231226_064840.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20231227113844_lumi.light.acn032_0.0.0_0026_20231226_064840.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240103161114_OTA_lumi.switch.n4acn4_V62_20240103_776DCB.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240112203928_lumi.switch.n0agl1_0.0.0.0030_20240112_C892CC.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240119171828_OTA_lumi.dimmer.rcbac1_0.0.0_0034_20240119_C8C27C.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240204163339_OTA_lumi.switch.acn059_0.0.0_0034_20240204_80D522.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240204163449_OTA_lumi.switch.acn058_0.0.0_0034_20240204_80D522.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240204163527_OTA_lumi.switch.acn057_0.0.0_0034_20240204_80D522.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240204163609_OTA_lumi.switch.acn056_0.0.0_0034_20240204_80D522.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240204163658_OTA_lumi.switch.acn055_0.0.0_0034_20240204_80D522.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240204163742_OTA_lumi.switch.acn054_0.0.0_0034_20240204_80D522.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240204163834_OTA_lumi.switch.acn049_0.0.0_0034_20240204_80D522.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240204163918_OTA_lumi.switch.acn048_0.0.0_0034_20240204_80D522.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240312112538_OTA_lumi.switch.n1acn1_0.0.0_58_20240311_02B313.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240411111850_OTA_lumi.light.cbacn1_0.0.0_0043_20240407_AE8330.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240415175402_OTA_lumi.light.acn004_0.0.0_0031_20240319_BB204F.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240620152417_lumi.curtain.acn003_Multi_JN5189_FMSH_0.0.0_3331_20240613_792592.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240719174346_OTA_lumi.plug.macn01_0.0.0_0036_20240719_40C5BB.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240719174937_OTA_lumi.plug.maeu01_0.0.0_0045_20240719_958E71.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240722115628_OTA_lumi.plug.sacn03_0.0.0_0038_20240719_39CCF1.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240722115926_OTA_lumi.plug.sacn02_0.0.0_0052_20240719_986BEB.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240724195823_OTA_lumi.switch.b3n01_0.0.0_0028_20240723_6A0037.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240726113823_OTA_lumi.switch.n2acn1_0.0.0_59_20240724_F96EFF.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240726114727_OTA_lumi.switch.n3acn1_0.0.0_59_20240724_1B883A.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240826103128_20240723105743_OTA_lumi.switch.b2nacn01_0.0.0_0028_20240722_296A66.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240830115847_OTA_lumi.switch.acn047_0.0.0_0032_20240823_D8294E.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/LM15_86SP_aq_V1.0.11_20170302_OTA_v11_withCRC.20170417201259.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/LM15_SP_aq_V1.3.30_20180724_v30_withCRC.20180724160524.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/LM15_ln1_AQ_V1.0.32_20180625_v32.20181008194104.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/LM15_ln2_V1.0.32_20180625_v32.20181008194246.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/LM19_BatteryCurtain_V1.0.24_20200803_Enc_F3D9.20200903160047.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_LM15_LNN_V2.6.22_20180503_neutral1_19ms_DIO19Led.20181011142357.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_LM15_LNN_V2.6.22_20180503_neutral2_19ms_DIO19Led.20181011142447.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_LMACN02_DoorLock_V4.1.09_20180317.20180411152155.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_LMAQ_DoorLock_V2.2.19_20171108.20180129142422.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_LM_WM_DoorLock_V2.3.13_20180409.20180412161023.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_WithCRC_LMES_RGBController_V1.2.30_20170801.20170920100827.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.airrtc.tcpco2ecn01_OTA_v12.20180828161433.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.airrtc.tcpecn02_OTA_v12.20180828161528.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.flood.agl02_V1.0.18_20190814.20191008104903.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.light.cwopcn01_V25_20200328_86DF8E.20200702155802.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.light.cwopcn02_V25_20200328_6C8C9C.20200702155957.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.light.cwopcn03_V25_20200328_0022DA.20200702160124.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.plug.mmeu01_V22_20190906_D32362.20191008105750.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.relay.c4acn01_V2.1.20_201900821_8FFEC9.20190906162416.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.remote.b286acn03_V1.0.21_20191127.20200310172748.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.sen_ill.agl01_V1.0.27_20200312.20200507152054.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.sen_ill.mgl01_V1.0.18_20190814.20191008105225.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.switch.b1laus01_0.0.0_0032_20200609_0C501F.20200811124320.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.switch.b1nacn01_0.0.0_0026_20211101_E70B9E.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.switch.b2laus01_0.0.0_0032_20200609_CC225A.20200811140905.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi.vibration.agl01_V1.0.25_20200528_F8C40C.20200529185424.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_lumi_switch_l3acn3_0_0_0_0027_20200619_283DA8_20200702151504.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_withCRC_LMES_Dimmer3Controller_V1.2.30_20170801.20170818101543.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_withCRC_LMES_DualController_V1.3.30_20170801.20170818100757.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_withCRC_LMES_HVACController_V1.2.30_20170710.20181024102131.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/OTA_withCRC_LMES_HVACController_V1_2_30_20170710_20170818101250.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/lumi.plug_20211224_v92.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/lumi.relay.c2acn01_20211201_v0047.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/lumi.switch.b1lacn01_0.0.0_0032_20200414.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/lumi.switch.b2lacn01_0.0.0_0032_20200414.ota",
+    "stack": "ZBOSS",
+    "stackDetails": "Nordic (fuzzy matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/lumi.switch.b3l01_0.0.0_0033_20200414.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/lumi.switch.n0acn2_0.0.0_0039_20211230_6DCD12.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/lumi.zzjq_1.1.35_20180824_v35.20180824161828.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/4512700-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/4512703-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/4512704-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/4512705-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/4512719-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/4512721-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/4512726-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/4512729-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/4512772-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/5401392-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/5401393-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/5401394-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/5401395-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/5401396-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/5401397-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/5401398-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/5401399-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/NAMRON_AS_4512737(6001)%20V22.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/NAMRON_AS_4512738(6002)%20V22.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-0002-0305-700_nodon_sin_4_2_20_fw_V0305.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-0005-0305-700_nodon_sin_4_1_21_fw_V0305.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-0006-0305-700_nodon_sin_4_fp_21_fw_V0305.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-0009-0305-700_nodon_sin_4_rs_20_fw_V0305.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-000A-0305-700_nodon_sin_4_1_20_V0305.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-0102-10101-700_nodon_sin_2_fm_stm32_V10101.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-0105-010500-700_nodon_sin_xx_met_fm_stm32_V010500.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-0106-010500-700_nodon_sin_xx_met_fm_stm32_V010500.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-0109-10102-700_nodon_sin_rs_fm_stm32_V10102.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-010A-010500-700_nodon_sin_xx_met_fm_stm32_V010500.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-2002-040300-700_p2022_HSP_tphu_fw_efr32_V040300.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-2003-040300-700_p2022_HSP_do_fw_efr32_V040300.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-2004-040300-700_p2022_HSP_dc_fw_efr32_V040300.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/NodOn/128b-4002-010600-nodon_irb-4-1-00_fw_V010600.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020509_CLA60_TW.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_CEILING_TW_OSRAM.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_CLA60_RGBW_OSRAM.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_CLA60_TW_OSRAM.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_CLA60_W_CLEAR.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_CLASSIC_A60_RGBW.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_CLASSIC_B40_TW.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_FLOOD_LIGHT_RGBW_OSRAM.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_GARDENPOLE_MINI_RGBW_OSRAM.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_GARDENPOLE_RGBW_LIGHTIFY.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_GARDENSPOT_RGB.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_GARDENSPOT_W.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_LIGHTIFY_INDOOR_FLEX.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_LIGHTIFY_OUTDOOR_FLEX.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_MR16_TW_OSRAM.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_OUTDOOR_LANTERN_B50_RGBW_OSRAM.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_OUTDOOR_LANTERN_B90_RGBW_OSRAM.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_OUTDOOR_LANTERN_W_RGBW_OSRAM.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_PANEL_RGBW_OSRAM.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_PAR16_50_TW.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_Par16Rgbw.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_Surface_Light_TW.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_MK_0x01020510_Surface_Light_W.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_Plug01_OnOff_MK_0x01020509.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Osram/ZLL_SubstiTube_W_MK_0x01020509.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Perenio/LDS_MotionSensor_1168-0402-41030002.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Perenio/LeakSensor_v5.OTA.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/CSB600_20170209.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/ECM600_09160525_V16.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/HS1SA_EM-SALUS-0621-V14-190907.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/Jasco_5_0_1_Dimmer_45857_v6.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/Jasco_5_0_1_OnOff_45856_v6.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/PumpWC_20170614V11_CRC.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/Repeater_20190415.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAA6UT1_00060962_20230628_1619.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL2PE1_02015120_OTA.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL2PU1_02015120_OTA.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL2SA1_20190415_OTA.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL2WB1_181214.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL6DB1_20190410_V2A_CRC.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL6DF1_003E0029_20221215_1652.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL6DFA_0066003E_20230909_0953.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL6DT1_009A74A4_20180627_1225.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL6DW1_20230222.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL6EM1_00910040_20210928_1336.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL6ET1_009A50A4_20180627_1222.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL6EV1_005F004F_20180228_1806.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAL6RS1_190612.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAR70WA_20231008_V72.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAR70ZA_20231008_V70.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU20T1_0064004E_20211113_1334.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU21T1_00270009_20230108_1655.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU22T1_00640050_20211113_1337.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU2AD1_170211.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU2AG1-ZC_20240531.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU2BD1_170206.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU2DA1_EFR32_APP_V20200508.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU2WB1_180918.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU51R1_20190619.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU61T1_00310012_20231120_1046.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU62C1_00310023_20231121_0942.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SAU62T1_0031001C_20231121_0940.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SB600_20170209.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SC904ZB_18012801.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SLG2CF1_20180116_v00160501.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SLG5CF1_00370009.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SND2DB1_001F0019_20230108_0849.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SQ605RF_V2.3_20201119.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SQ610RF_APP_V3.8_20221212.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/SQ610_APP_V3.5_20230403.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/ST880ZB_EM357V92_MCUV78.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/Salus_Smart_Plug_SX885ZB_21030500.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/StreamTRV_00910040_20210928_1427.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/WindowSensor_20240103.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/it600WCNH_00090005.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SalusControls/sau2aw1_V19121102.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL ENC",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sengled/1555679540244_RDS2017009_E11_U2E_V42_20190418_release.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sengled/1586412538195_RDS2017007_E11-N1EA_V0.0.71_20200311_release.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sengled/1594189489604_RDS2017039_E12_N1E_V0.0.30_20200630_SVN396.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sengled/1594881275531_RDSE2020003C0511_E1G-G8E_05m_10m_V0.0.14_20200711_release.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sengled/RDL2016091_1_E11-G13_V0.0.9_20170921_release.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sengled/RDS2014011_Z01-A19_V0.0.46_20171028_release.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sengled/RDS2017028_E1C-NB6_V0.0.22_20180314.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sonoff/s40zbLite_v1.0.3.ota",
+    "stack": "zStack",
+    "stackDetails": "CC13x2R1",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sonoff/snzb-05p_v1.0.2.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sonoff/snzb-06p_v1.0.6.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sonoff/zbmicro_v1.0.5.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sonoff/zbmini-l_v1.1.1.ota",
+    "stack": "zStack",
+    "stackDetails": "CC13x2R1",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sonoff/zbminil2_v1.0.14.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sonoff/zbminir2_v1.0.4.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sonoff/zbswv_v1.0.4.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sprut.device/wb_msw3_0_061.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sprut.device/wb_msw3_A_061.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sprut.device/zb_wb_msw4_mg21_065.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sprut.device/zb_wb_msw4_mgm21_065.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Telink/1141-0208-01143001-ZMHOC401N.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Telink/1141-0208-01233001-ZMHOC401N.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Telink/1663234985-oem_ztu_dimmer1_klt_OTA_1.0.6.bin",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Telink/1686137326-oem_zg_tl8258_plug_OTA_1.0.14.bin",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Telink/1718263020-oem_zg_tl8258_plug_OTA_1.1.0.bin",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Terncy/TERNCY-SD01_v46.OTA",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/Button_PROD_OTA_V35_v1.00.35.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/Door_Sensor_PROD_OTA_V63_v1.00.63.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/FW_ha_v1.00.82.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/Motion_Sensor_PROD_OTA_V79_v1.00.79.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/SmartCurtain_PROD_OTA_V76_v1.00.76.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/SmartPlug_Zigbee_PROD_OTA_V92_v1.00.92.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/SmartSwitchGen3_PROD_OTA_V30_v1.00.30.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/Soil_Moisture_Sensor_PROD_OTA_V31_v1.00.31.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/TRTL_ThermalSensor_PROD_OTA_V37_v1.00.37.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/ThermalLiteSensor_PROD_OTA_V29_1.00.29.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/Water_Leak_Sensor_PROD_OTA_V66_v1.00.66.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/1615190575-si32_zg_uart_connect_sleep_ZS5_ty_OTA_1.1.7.bin",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/1622438235e5764b7a861.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/1662545193-oem_zg_tl8258_plug_OTA_3.0.0.bin",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/1662693814-oem_mg21_zg_nh_win_cover_relay_OTA_1.0.7.bin",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/16781822109542aac900a.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/1678411825b98a1530a8c.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/16819629247ee0445a5f4.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/16844823767736d4b2cbc.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/16855062966c6d846535c.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/ZB21S3_HZC_Dimmer1_ECO_1.01_20221021.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/ZPS_CS5490_039.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "EBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Tuya/home_control_as_hc_slm_1_00.02.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/UHome/007B-0141-00002867-good_image_PL_1_3_43.zigbee",
+    "stack": "ZBOSS",
+    "stackDetails": "Nordic (fuzzy matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/UHome/007B-0141-010E0101-good_image.zigbee",
+    "stack": "ZBOSS",
+    "stackDetails": "Nordic (fuzzy matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B01-0000-0006-0192020D-spo-fmd.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B02-0000-0001-0192020D-spo-fms.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B03-0000-0006-0191020D-spo-fms2.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B04-0000-0007-0191020D-spo-fmsh.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B05-0000-0004-0191020D-spo-rms.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B06-0000-0004-0191020D-spo-rms2.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B07-0000-0004-0191020D-spo-rmsh.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B08-0000-0004-0192020D-spo-rmd.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B09-0000-0004-0192020D-spo-fmi4.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B0A-0000-0005-0193020D-m7b-r0.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B0B-0000-0001-01900210-m7b-h10.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B0C-0000-0000-01000206-m7b-wd1.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B0D-0000-0001-01500427-m7b-h1.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B11-0000-0001-00940240-m7b-q95.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B21-0000-0006-0194020E-spo-fmd.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B22-0000-0001-0193020D-spo-fms-rev0-1.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B23-0000-0006-0192020D-spo-fms2.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B24-0000-0007-0192020D-spo-fmsh.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B25-0000-0004-0192020D-spo-rms.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B26-0000-0004-0192020D-spo-rms2.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B27-0000-0004-0192020D-spo-rmsh.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B28-0000-0004-0195020E-spo-rmd.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B29-0000-0004-01940221-spo-fmi4.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B2A-0000-0005-02010230-m7b-r0.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B2B-0000-0001-01920210-m7b-h10.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B2C-0000-0001-0150044D-ld6.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B2D-0000-0001-0172044D-m7b-h1.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B31-0000-0006-02500447-spo-fmd.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B32-0000-0001-02500447-spo-fms-rev0-1.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B33-0000-0006-02500447-spo-fms2.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B34-0000-0007-02500447-spo-fmsh.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B35-0000-0004-02500447-spo-rms.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B36-0000-0004-02500447-spo-rms2.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B37-0000-0004-02500447-spo-rmsh.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B38-0000-0004-02500447-spo-rmd.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B39-0000-0004-02500447-spo-fmi4.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B3A-0000-0005-02500447-m7b-r0.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B3B-0000-0001-02500447-m7b-h10.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B45-0100-0100-0250044D-ubisys-s1r-qpg6105.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B49-0100-0100-0250044D-ubisys-c4-qpg6105.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B4A-0100-0100-0250044D-ubisys-r0-qpg6105.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/xyzroe/ZigUSB_C6.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/Vibrate_Sensor_PROD_OTA_V55_v1.00.55.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0331-191d3685-sp240-1.9.29.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0332-191d3685-sp242-1.9.29.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0333-191d3685-sp244-1.9.29.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0334-191e3685-sp240v2-1.9.30.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0335-191e3685-sp242v2-1.9.30.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Innr/1166-0336-191e3685-sp244v2-1.9.30.ota",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/Namron_4512750_v32_2025_02_14.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sonoff/trvzb_v1.3.0.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240731114104_OTA_lumi.switch.b1nc01_0.0.0_0029_20240729_69827E.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240731114846_OTA_lumi.switch.b2nc01_0.0.0_0029_20240729_4EDD09.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/Radar_PROD_OTA_V6_v1.00.06.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/GarageDoorSensor_PROD_OTA_V36_v1.00.36.ota",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Jennic/PMM300Z3_OTA_ENC_V8_ENC.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Hue/100B-0129-01000D06-Light-EFR32MG26.zigbee",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Inovelli/mmwave_module_fw_V3_14_3.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Sonoff/snzb-02d_v2.3.0.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B02-0002-0007-0192020D-spo-fms.ota1.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B22-0002-0007-0193020D-spo-fms.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Ubisys/10F2-7B32-0002-0007-02500447-spo-fms.ota.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Develco/ED%20-%20HA%20-%20Smoke%20Sensor%20Mini-4.0.9.zigbee",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/ThirdReality/Zigbee_A19_Bulb_OTA_V66_1.00.66.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PLUG_EU_EM_T-0x00DC-0x033D3674-MF_DIS.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/LEDVANCE/PLUG_COMPACT_EU_EM_T-0x00E6-0x033D3674-MF_DIS.OTA",
+    "stack": "Telink",
+    "stackDetails": "(fallback matching)",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Lumi/20240625145706_lumi.sensor_occupy.agl1_0.0.0_0028_20240621_AA55A4.ota",
+    "stack": "Unknown",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Inovelli/VZM32-SN_0.04.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SlackyDiy/6565-0391-10153001-tuya_thermostat_zrd.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Inovelli/VZM30-SN_0.04.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SlackyDiy/6565-0204-20043001-watermeter_zed.zigbee",
+    "stack": "Telink",
+    "stackDetails": "TLSR8258",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/SlackyDiy/6565-0393-10023001-tuya_co2sensor_zrd.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Namron/4512761-Firmware-35.ota",
+    "stack": "EmberZNet",
+    "stackDetails": "GBL",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0201-01253001-ZMHOC401.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0202-01253001-ZCGG1.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0206-01253001-ZCGDK2.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0207-01253001-ZCGG1N.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0208-01253001-ZMHOC401N.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-020a-01253001-Z03MMC.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-020b-01253001-ZMHOC122.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0211-01253001-ZTS0201Z3000.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0216-01253001-ZTH03Z.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-021b-01253001-ZTH01Z.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-021c-01253001-ZTH02Z.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-021e-01253001-TH03Z.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-021f-01253001-LKTMZL02Z.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0221-01253001-ZTH05.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0225-01253001-ZYZTH02.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0226-01253001-ZYZTH01.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/pvvx/1141-0227-01253001-ZG227Z.zigbee",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Telink/oem_tl8258_zg_breaker_OTA_1.0.10.bin",
+    "stack": "Telink",
+    "stackDetails": "",
+    "zigbeeStackVersion": "ZigBeePro"
+  }
+]

--- a/index.json
+++ b/index.json
@@ -17,7 +17,7 @@
     "imageType": 12302,
     "manufacturerCode": 4617,
     "sha512": "901d7b98b3448df06ba0e87465b9140d80e0ef41cdb2c1880c9788a562bcfefd3cd306f2f737007c7f96ad02b3d230391d0d88940ef9c9e976c792bc80d935d2",
-    "otaHeaderString": "RTH2_230\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "RTH2_230"
   },
   {
     "fileName": "0x1209_0x3011_0x03076a30.ota",
@@ -27,7 +27,7 @@
     "imageType": 12305,
     "manufacturerCode": 4617,
     "sha512": "63f232232252af0fbb3c4cc2efe2ce2564101405de4923238c71ccef2e66e6abef022deee45399a886af4019dfce64fdea969ff60f5b4b854e222b5ffcf7bcc2",
-    "otaHeaderString": "RTH2_230\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "RTH2_230"
   },
   {
     "fileName": "ota_t0x3002_m0x1209_v0x2a006a30.ota",
@@ -37,7 +37,7 @@
     "imageType": 12290,
     "manufacturerCode": 4617,
     "sha512": "e321384272c1cb5b11bd259ecc8f06d64ae50b193d6057e5221c2d56c55871d1387fdd72c11356f8b9d85f2f68f3906f3b11a49e7140848078ac60ce73723dc3",
-    "otaHeaderString": "PLUG_EU\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PLUG_EU",
     "modelId": "RBSH-SP-ZB-EU"
   },
   {
@@ -48,7 +48,7 @@
     "imageType": 12298,
     "manufacturerCode": 4617,
     "sha512": "834531102c17686c831a3e0e0b78b402643a50c42264fa326fbe32213a0c104bc036befcdf51f330cbbf5c6c95d38a028365c3bbaf7feaa453e4d11792f79f36",
-    "otaHeaderString": "RBSH-TRV0-ZB-EU\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "RBSH-TRV0-ZB-EU",
     "modelId": "RBSH-TRV0-ZB-EU",
     "releaseNotes": "1. Fix error E03, which can happen on some radiators after some time"
   },
@@ -60,7 +60,7 @@
     "imageType": 2017,
     "manufacturerCode": 10132,
     "sha512": "5e36ceaa44c4b3e12f4ff415b00fb16a3d64aaa3d8bebaecc0590480f4850e8ff226be20356417da223679c4210b5c69e8159ae15628c098c59d074e86d97258",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "PRS3CH1_00.00.05.11TC.zigbee",
@@ -70,7 +70,7 @@
     "imageType": 1025,
     "manufacturerCode": 10132,
     "sha512": "76a327ab014803b6f18376343b1f75de474e7e5ad1b6a0e276668052362e6aff2bccf44bf92683217228cd4049fa1b273231284f4a25aac7858b363f2b09e05b",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "modelId": "PRS3CH1_00.00.05.11TC"
   },
   {
@@ -81,7 +81,7 @@
     "imageType": 1025,
     "manufacturerCode": 10132,
     "sha512": "904609129ff2445cc36e0a01033d584797bd784a2033defc2dd1b2f269e9318b6f6bd31f8b1d07e308c4281243bfbde72219de347b6c23e3a1fd4300bfe17aa9",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "modelId": "PRS3CH2_00.00.05.12TC"
   },
   {
@@ -92,7 +92,7 @@
     "imageType": 515,
     "manufacturerCode": 56085,
     "sha512": "2a7a17f348f6631e10217d689456ddeceaf768e06267a76a93335a8fb0ee57dfda88e84830536eb478977e423d3add9ff0590839b8736e465e216d0d81f474e9",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "115C-0004-11040000-ZigbeeXM_101-029_E1_DanalockV3_17.4.0_20221213143911.ota",
@@ -102,7 +102,7 @@
     "imageType": 4,
     "manufacturerCode": 4444,
     "sha512": "44e421aecf5b0c5793a1ba836257f8601408e1dcc2832846b0093e7c2f2a4c100632b8a71ef346b9c611be1d15602bcc3b693002994830b8e857da6e931f6722",
-    "otaHeaderString": "Danalock V3 BTZBE XM\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Danalock V3 BTZBE XM",
     "modelId": "V3-BTZBE"
   },
   {
@@ -113,7 +113,7 @@
     "imageType": 4,
     "manufacturerCode": 4444,
     "sha512": "9e45e56b0aef871e1280c678729fdce0a57628d40e569fbc3c26bca5acc2a5c4088a90cbd59c9b6ea378d5c450310e04766b133333b23e7b4520e5c80282e334",
-    "otaHeaderString": "Danalock V3 BTZBE XM\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Danalock V3 BTZBE XM"
   },
   {
     "fileName": "PSoC4_1246-0100-01280128.0002_(4CA01CD1).ota",
@@ -123,7 +123,7 @@
     "imageType": 256,
     "manufacturerCode": 4678,
     "sha512": "63dafd3332dd2f8901a5094c5d8437861244b78c6348bc3be2b3e7a135e33765cad0001dd842f22a992978e34afe4f7674e082092f03d35040dc0e3fda5f6ae6",
-    "otaHeaderString": "Thu 11/09/2023 V.011C.011C\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Thu 11/09/2023 V.011C.011C"
   },
   {
     "fileName": "PSoC6_1246-0120-00280028.0002_(90215AC0).ota",
@@ -133,7 +133,7 @@
     "imageType": 288,
     "manufacturerCode": 4678,
     "sha512": "2be3ce5ff9e9b378a447285a7f2f099313a8ec067c5565b0ceb9fcb917ba663d022b05ceaeddd20d0205d9b98b1c2986570699d749031f4b54ffd04d14d593c8",
-    "otaHeaderString": "Thu 11/09/2023 V.001C.001C\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Thu 11/09/2023 V.001C.001C"
   },
   {
     "fileName": "ctm_mains_power_outlet.ota",
@@ -143,7 +143,7 @@
     "imageType": 4099,
     "manufacturerCode": 4919,
     "sha512": "4b161a3ea4586657f249ff6de7e8134b1fee6658b99574e1e5bc34a71ab3647513e86dcc38c1b7af0eba1810c5f0d9773c1a69cf64129c34bf567384e5b1cc17",
-    "otaHeaderString": "EBL ctm_mains_power_outlet\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL ctm_mains_power_outlet"
   },
   {
     "fileName": "ctm_mbd-s_2_5.ota",
@@ -153,7 +153,7 @@
     "imageType": 4109,
     "manufacturerCode": 4919,
     "sha512": "583cb7e4829174f225d8f99d82e49b764de30c4f7b35cb9002d183ad237c58305eca1436abff6607671b66a549807b77d45558d204868bb5bc9eed6132929123",
-    "otaHeaderString": "EBL ctm_mbd\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL ctm_mbd"
   },
   {
     "fileName": "dimmerpille_v2_0_v_4_combined_OTA.ota",
@@ -163,7 +163,7 @@
     "imageType": 4114,
     "manufacturerCode": 4919,
     "sha512": "a4c805a4769d38f6ed9ffad358573aeb4e3dceaba2d3b2cf693f39e64fa94a5cc7a8efdc6c5363521c54d9e6c10901fd1606af674fde2e60bcbb96ad4c79daf0",
-    "otaHeaderString": "EBL ctm_mtouch_dim\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL ctm_mtouch_dim"
   },
   {
     "fileName": "eva_meter_reader-2.0_MG21.ota",
@@ -173,7 +173,7 @@
     "imageType": 8224,
     "manufacturerCode": 4919,
     "sha512": "2dd671e994f521d602f083e4f3a7720e9d251672e1b4068333a0025a9de9519f8b6d629c4b55d0ef8cc44735d8ce98cea9b477c1a92526fe5a72eb762b70dacc",
-    "otaHeaderString": "EBL eva_meter_reader\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL eva_meter_reader"
   },
   {
     "fileName": "han_adapter-0.7_MG13_nonreworked.ota",
@@ -183,7 +183,7 @@
     "imageType": 8205,
     "manufacturerCode": 4919,
     "sha512": "d5e28bcae888e97f6cc59c18fb9e406dbd53bf2b796b3807e1247a6d831a2bece433f8961702fe7437b5a26fe26b30ddcc802cc4d15660d27fd2be31b1311ff5",
-    "otaHeaderString": "EBL han_adapter\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL han_adapter"
   },
   {
     "fileName": "han_adapter-2.0_MG13_reworked.ota",
@@ -193,7 +193,7 @@
     "imageType": 8226,
     "manufacturerCode": 4919,
     "sha512": "516f3a1b31f6018cc794c3959adb0eac84e6477db2a60b8eba63f10ac9527e5d9368d9cbbd5e4257ea7587f1b58c3132c43f0bd788dac93819ab24caa1671150",
-    "otaHeaderString": "EBL han_adapter\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL han_adapter"
   },
   {
     "fileName": "mTouch_Dim_v3_1_v35_combined_OTA.ota",
@@ -203,7 +203,7 @@
     "imageType": 4113,
     "manufacturerCode": 4919,
     "sha512": "0c175bed4bef94a26541d6a1fc8cfdff6c78d2234d479fa3b2a542fe642b41324282feebfad1140ca5d3aa8221d12a8fffb385eaf0e3c41372b663bdadbcd126",
-    "otaHeaderString": "EBL ctm_mtouch_dim\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL ctm_mtouch_dim"
   },
   {
     "fileName": "mTouch_One_v3_8_v72_combined_OTA.ota",
@@ -213,7 +213,7 @@
     "imageType": 4102,
     "manufacturerCode": 4919,
     "sha512": "11e455bb88f247c8b7e99db34c5d760a23da7097214cc2cb15f369617e91a94da1189fe81b5ecfadbb9fcd22f8ec66a1a5087bc9aac3e0af47be34f888416062",
-    "otaHeaderString": "EBL mTouch_One\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL mTouch_One"
   },
   {
     "fileName": "mains_power_outlet_2.7.ota",
@@ -223,7 +223,7 @@
     "imageType": 0,
     "manufacturerCode": 4919,
     "sha512": "431e3fb76a5bde82947a925099d5b5b8639c2e0ba1ad6fe85e7dcd598a8f43c41a86bb78c34ee2fdbe4ae5465e35bb2e24065408fe4aa13c492881848214b6ab",
-    "otaHeaderString": "EBL mains_power_outlet\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL mains_power_outlet"
   },
   {
     "fileName": "ED - HA - VOC Sensor-SSIG 4.0.1.zigbee",
@@ -233,7 +233,7 @@
     "imageType": 800,
     "manufacturerCode": 4117,
     "sha512": "d6779d7e0879c86d8a7479f352d187cb854cc8586b57245dc96f6c202ccf455a19acb5d360b9ae62510e5b7ae2ea67a95841ff822a5a3a69199d5841dbcf2dbe",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "EMI2LED_3.1.2.zigbee",
@@ -243,7 +243,7 @@
     "imageType": 976,
     "manufacturerCode": 4117,
     "sha512": "fa53c339b61a8980c3d8d42319be4f57aa088d98b8f87393a6fce84c2bd224079c26ca2b097f2a3bf042f629adf32bac90460e17d0b7a28864f244453e262baf",
-    "otaHeaderString": "EMI 2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EMI 2"
   },
   {
     "fileName": "EMI2P1_3.1.7.zigbee",
@@ -253,7 +253,7 @@
     "imageType": 977,
     "manufacturerCode": 4117,
     "sha512": "4ad740da6eaba7cbfbc3847f101c264a6df99b3bed6a6223721d4ce28cb39ef28a8a655d94aa9a33721fb0c1621d26d8c2b4f2b1968e3b8016b6125964e99a14",
-    "otaHeaderString": "EMI 2 - P1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EMI 2 - P1"
   },
   {
     "fileName": "EmiNorwegianHan_4.0.7.zigbee",
@@ -263,7 +263,7 @@
     "imageType": 832,
     "manufacturerCode": 4117,
     "sha512": "cbc9158bc45d7a819d56ed72dc9b53c717371ccc25a17e84ea13819ce62c5a50cc549602b4b7979dd70561be5e1c4c0a31ba2899a15a20730d894165f3c4a487",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "EntrySensor2_2.0.6.zigbee",
@@ -273,7 +273,7 @@
     "imageType": 928,
     "manufacturerCode": 4117,
     "sha512": "49b5c712b9e5ef91440bece5512cfc66d112e99c4d43c2f9d9755617d0ce302ffad2cd7b981769457d060c58e7e3950f9eb208583be87c98d638ac47fb1dda1d",
-    "otaHeaderString": "WindowVibrationSensor\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "WindowVibrationSensor"
   },
   {
     "fileName": "EntrySensor_4.0.2.zigbee",
@@ -283,7 +283,7 @@
     "imageType": 576,
     "manufacturerCode": 4117,
     "sha512": "839eff218970eb619c9f15ae63f435da50d2cf93f44569de4fea56d63d49c888031b1ee0714e447b39f90664eaa490bf619b8eac641c296a27b609e78c61fc56",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "HumiditySensor_4.0.1.zigbee",
@@ -293,7 +293,7 @@
     "imageType": 784,
     "manufacturerCode": 4117,
     "sha512": "a5bae0c769d58e788ba146b40c65ccd32d26d4934f6291a48f5bf23e13266c9ddd5afe310a47dcc5592c1865572e723da69171f1d43f1c669ed153d670b3afb5",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "IntelligentKeyPad_2.0.5.zigbee",
@@ -303,7 +303,7 @@
     "imageType": 915,
     "manufacturerCode": 4117,
     "sha512": "59b62aab3326b662f6e21a0327440db4836e55a618c7ce7b2cf5578c7b847cd9d08d8e6c431feb714f87a3556c1951069466f3986effa8dd5e1f91b39f3edd53",
-    "otaHeaderString": "KeyPad\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "KeyPad"
   },
   {
     "fileName": "MotionSensor2_2.0.6.zigbee",
@@ -313,7 +313,7 @@
     "imageType": 387,
     "manufacturerCode": 4117,
     "sha512": "4e78aa73ceec45e03606a67ba5e05d930862e01afc8fc81c86fa3cfa4b5433d3b2a785187afb1983c2b1874db5a9ab10d1a22876ddb9cf6a15252cc600c518d0",
-    "otaHeaderString": "MotionSensor\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "MotionSensor"
   },
   {
     "fileName": "MotionSensor_4.0.6.zigbee",
@@ -323,7 +323,7 @@
     "imageType": 386,
     "manufacturerCode": 4117,
     "sha512": "6ed82ead9881ae40347b51127aef48309cd54b78f0be3d46b42337cd34a095b49d9fe0bce434c06059136292bd33d6f8e44cd46a9d7a6d1c9c9934d10ab64af3",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "SmartButton_2.0.2.zigbee",
@@ -333,7 +333,7 @@
     "imageType": 913,
     "manufacturerCode": 4117,
     "sha512": "79a014db8559dd8ec42d3d867d3330eee0208904eb5169a3fe47a072b341486864dd4a62bfb7bb42f00aa62a7c2d36ef861842441cbd46e44fca37b98b28097c",
-    "otaHeaderString": "PanicButton\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "PanicButton"
   },
   {
     "fileName": "SmartPlug2_2.0.5.zigbee",
@@ -343,7 +343,7 @@
     "imageType": 737,
     "manufacturerCode": 4117,
     "sha512": "3c91179db3e65ff0bb361a84844ef1e096249af586f0e548bb72ac9bf27096113f90f14ffd0d222fdb792865a28368c58c072a895f87598bd44543275d6a766f",
-    "otaHeaderString": "Router - Smart Plug\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Router - Smart Plug"
   },
   {
     "fileName": "WaterLeakDetector_4.0.4.zigbee",
@@ -353,7 +353,7 @@
     "imageType": 768,
     "manufacturerCode": 4117,
     "sha512": "382a13ab21fa9aed73f136b42f565444ba4ebc115d437a1af6868cad0fca86376fb2f48407056aa511cd77321897981a52bec890b9810aff1af15ac6b072d385",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "ZR_Smartplug_SSIG_3.12.16.zigbee",
@@ -363,7 +363,7 @@
     "imageType": 736,
     "manufacturerCode": 4117,
     "sha512": "eaf4e925dbdf32f171fb8323c52b8652620dea5d62bc007e61ee61d276bdd90f097400a1c1bc48980d78c276117415e274c34529b481be82c28cd3695e2be817",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "ZigbeeRangeExtender_2.0.2.zigbee",
@@ -373,7 +373,7 @@
     "imageType": 916,
     "manufacturerCode": 4117,
     "sha512": "bec200a43bc7a51c58e70caa9d057006cbab54e5b058a8191a52d40e9aa8d1b979d2695ce0b4b0d4d1db6e926cce95bc1ae0a9e0810773b6c28ddb6705f4e248",
-    "otaHeaderString": "Router - Range Extender\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Router - Range Extender"
   },
   {
     "fileName": "1135-0000-201000F5-FLS-PP3_RGBW_16Mhz.zigbee",
@@ -383,7 +383,7 @@
     "imageType": 0,
     "manufacturerCode": 4405,
     "sha512": "5aa0a6156c8fe672b0fdfcc6e97bb21244cc5497ca86b75c2d371db85c0712334f88886a0903723f9230c21c6f3ee3a19a0e6ebdcdfc2ac5390fd4c8830be402",
-    "otaHeaderString": "�w}6@\u0000`>@\u0000\u0013p@\u0000\u0001\u0000\u0000\u0000�6@\u0000�\u0015@\u0000 �@\u0000��"
+    "otaHeaderString": "�w}6@`>@\u0013p@\u0001�6@�\u0015@ �@��"
   },
   {
     "fileName": "1135-0100-1000002A-Kobold.zigbee",
@@ -393,7 +393,7 @@
     "imageType": 256,
     "manufacturerCode": 4405,
     "sha512": "0905f0e6a469be3893f2c665156f18077258e24439e283c9f4b121553a94e8eb142e6250e721585ddd9aceef75da3c10a03defaee89885d7cb8f08449a20912d",
-    "otaHeaderString": "`\u0000�.@\u0000\u0010/@\u0000\u0000\u0000�n`\n�t�\u0015@\u0000\u0000\u0016@\u0000 �@\u0000��",
+    "otaHeaderString": "`�.@\u0010/@�n`\n�t�\u0015@\u0016@ �@��",
     "originalUrl": "https://deconz.dresden-elektronik.de/otau/1135-0100-1000002A-Kobold.zigbee"
   },
   {
@@ -404,7 +404,7 @@
     "imageType": 257,
     "manufacturerCode": 4405,
     "sha512": "2fdcef8bb3d69f5f534d60982fbfba4078b15a963948e1549367732df431f0076abe0bc8f8183585e850cdc55826509aa2d431001026d1aa242cd8c7a93af8af",
-    "otaHeaderString": "`\u0000�.@\u0000\u0010/@\u0000\u0000\u0000�n`\n!v�\u0015@\u0000\u0000\u0016@\u0000 �@\u0000��"
+    "otaHeaderString": "`�.@\u0010/@�n`\n!v�\u0015@\u0016@ �@��"
   },
   {
     "fileName": "ZB21S3_HZC_Dimmer1_EcoDim-Zigbee 3.0_1.01_20230908.ota",
@@ -414,7 +414,7 @@
     "imageType": 1000,
     "manufacturerCode": 4714,
     "sha512": "9b7835e32ef5af35385710332838099c5dce99a398ae04a1a769d67935fb0752ca4da58892f13bc842cbf8f9ae20516142fe9b66eff3e8ebef6577a71a1d9b0b",
-    "otaHeaderString": "EBL D581_ZG\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL D581_ZG"
   },
   {
     "fileName": "TICMeter.ota",
@@ -424,7 +424,7 @@
     "imageType": 200,
     "manufacturerCode": 65535,
     "sha512": "67f0bfdbb7d2cdeee4d54d2ad44dc04b42ac9401f02c92fcde5db3010d5706027d793405a601bcf18bb789cfc46cacc4887bee1b59f42c234177135d1ea9ffb0",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://update.gammatroniques.fr/ticmeter/V3.2.13/download/TICMeter.ota",
     "modelId": "TICMeter"
   },
@@ -436,7 +436,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "8c3431b4d60d31e3ac16468601b64b3f8da0c2cf122c638a654b71543de901bfaf2e3afe5a0a8084d20d32478ad61738c86f33a2548211ea8f2367900fb1b620",
-    "otaHeaderString": "EBL ARGBW_V_0_1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL ARGBW_V_0_1",
     "modelId": "GL-B-007P"
   },
   {
@@ -447,7 +447,7 @@
     "imageType": 5154,
     "manufacturerCode": 4687,
     "sha512": "5edf31594046cd881aa47ba966909ead5e065f3c6816a30cbeea6499845313d24f27fbdc491ab02b181a8015134949cb5fb78ef76418a5cfcc982241c9e401ac",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "modelId": "GL-B-007P"
   },
   {
@@ -458,7 +458,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "788341b48089076a6d1c6f020f34699428adc5103ba18d54fe3b0b00bbee2212bef13ba853fe3f1c1fb247f6d17d29608a937ed897fdd9e5b5294b4ceee13ebe",
-    "otaHeaderString": "EBL ARGBW_V_0_1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL ARGBW_V_0_1",
     "modelId": "GL-B-008P"
   },
   {
@@ -469,7 +469,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "8eb197dc7e6f92afca457ce585e754ac3bf39e53cfb3f2e2433bf6317c51e0987cfe9224db046bf24522069651a85defe3bf62531c9eb4f2955b402ab55e9002",
-    "otaHeaderString": "EBL ARGBW_V_0_1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL ARGBW_V_0_1",
     "modelId": "GL-C-008P"
   },
   {
@@ -480,7 +480,7 @@
     "imageType": 5202,
     "manufacturerCode": 4687,
     "sha512": "64df9200d6f1a48c8561dd6bfb8b0949fcb0b30a87c740674205e9a0f383844d66686479ed7480076a6ea3cd3c42fe4f1c7af55356132fdc9d4c571096604696",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "GL-D-005P_V11076801_OTAV12_20211108_60%.ota",
@@ -490,7 +490,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "966bbc8a44693eb5a91c4cf64bf59b91d291335d223cec1ffc65a6d7b3fe339be4e70b90908aea0bc0a6f7ea4ff130898b4492e0818d7f05220582097a543f9d",
-    "otaHeaderString": "EBL ARGBW_V_0_1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL ARGBW_V_0_1",
     "modelId": "GL-D-005P"
   },
   {
@@ -501,7 +501,7 @@
     "imageType": 5204,
     "manufacturerCode": 4687,
     "sha512": "0a6ee5e0d447ebe278f3c5c594a3850185f8dd04ec41f5618ba58b0c28eae31e9145f77c4ddf173d1a3d9e48a4306232fa6a264512aa38c395a28ae72501bd85",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "GL-D-007P.ota",
@@ -511,7 +511,7 @@
     "imageType": 5155,
     "manufacturerCode": 4687,
     "sha512": "fbeba0b73f91a865a5200c77b75589b53369b44d97d3ed445e0f36f0d581372bf4b414cff7dd32eadfb9e57d4c431639f76344cba62d6125044be1b564d995ec",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "GL-D-007P_V105_20220418(1).ota",
@@ -521,7 +521,7 @@
     "imageType": 5205,
     "manufacturerCode": 4687,
     "sha512": "8d51a793c2591aa494cda1bfe16eb5095bebdd1338604222c0ca5ac44006959ee740692eb193c8416c92d6607602a741745ec3f76b8ed1dabea3d548685bdcf3",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "GL-FL-005P_V14_OTAV4_20210119_100%.ota",
@@ -531,7 +531,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "35815df1ef7ec3f492076f118c77bf21a846ea68c07766f574eeb67d34cb00cee8e374edabfba47c1b66763c222c1ce2133a06cae8bece483b0be9d90f54a2b8",
-    "otaHeaderString": "EBL ARGBW_V_0_1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL ARGBW_V_0_1",
     "modelId": "GL-FL-005P"
   },
   {
@@ -542,7 +542,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "fec3c2e153d30a3a01193b0b7a96e3ef2e6613d1de58e5ee01d6d66baf7d2d4e8c1bd94b3aece0effc94145e8b5b783f192ff752a9ae640044b895faabbbcd63",
-    "otaHeaderString": "EBL ARGBW_V_0_1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL ARGBW_V_0_1",
     "modelId": "GL-FL-006P"
   },
   {
@@ -553,7 +553,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "111b3620c7bc4f989d9814ed35b968708048f445cf87d04a2432c460ff7892001c18e9f899d7504916a2005d99fd116751fc4c6cee65db80c29d297cfbbe5a84",
-    "otaHeaderString": "EBL ARGBW_V_0_1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL ARGBW_V_0_1",
     "modelId": "GL-G-001P"
   },
   {
@@ -564,7 +564,7 @@
     "imageType": 5172,
     "manufacturerCode": 4687,
     "sha512": "e71026da82d79c789b859a82792b7a45b91e58175a6fe6ac2a77deb9c4c295656647866b513ebc3fbfe38f58c2a72598de36b34abb2b6294788ccc2791fcd456",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "GL-S-007P_V15_A1_OTAV5_20210201_90%.ota",
@@ -574,7 +574,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "ce512a11f0d4e603edd3a93686cf5d666ee447bee1d24a6e06ce544e2ebf941a4a4e3fcc737cdf8c65821f8e008366b269d9a221fb55cfa54065380442c5f432",
-    "otaHeaderString": "EBL ARGBW_V_0_1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL ARGBW_V_0_1",
     "modelId": "GL-S-007P"
   },
   {
@@ -585,7 +585,7 @@
     "imageType": 268,
     "manufacturerCode": 4107,
     "sha512": "c4591fe155bef8500779c36c7792f3960c4f83dde9dd47aa367113229c5bd73161f14cc92e6d6a0960e807c54626ce2ab0ce0d18c76d0206770dcda3a4776862",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_010C/2ef158a5-ffb4-43ac-9d59-3cb71078f6f7/100B-010C-01001A02-ConfLight-Lamps_0012.zigbee",
     "maxFileVersion": 16783873
   },
@@ -597,7 +597,7 @@
     "imageType": 268,
     "manufacturerCode": 4107,
     "sha512": "30c754504fed42ce12b4243fbf70a8207675f02cba1efbe2e454270049b472e400578c316602978deadb39166b196cb21aaf0f5cbb527fd2491fd78d4a14b620",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_010C/9ee7aed8-faed-43eb-b7f7-712a5b578dba/100B-010C-01002800-ConfLight-Lamps_0012.zigbee",
     "minFileVersion": 16783874
   },
@@ -609,7 +609,7 @@
     "imageType": 270,
     "manufacturerCode": 4107,
     "sha512": "5843552ab361d2d063e36be24785afcb8af34491ae721c2426da6afec94967acd4005d5e2abfcca5ebd10f3c9e39656524775b50cef115f67c3f636b9609d3c2",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_010E/3e979745-cc00-43cf-a51c-73a3d9d91430/100B-010E-01001904-ConfLight-ModuLum_0012.zigbee",
     "maxFileVersion": 16783619
   },
@@ -621,7 +621,7 @@
     "imageType": 270,
     "manufacturerCode": 4107,
     "sha512": "f22b61f43ec9a98991825ba492d5373c1e617d62508fa538ef0ae6b5e51ec3419e2b9b15328770918b06391bf3b0adb18d747251bb615e189c43171abf0b3f07",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_010E/05e4122d-0d51-41df-91af-7d1aae4cc0a0/100B-010E-01002600-ConfLight-ModuLum_0012.zigbee",
     "minFileVersion": 16783620
   },
@@ -633,7 +633,7 @@
     "imageType": 271,
     "manufacturerCode": 4107,
     "sha512": "af6c7538574a11d11f055563dd396f6f3d2fbe1312f8cd8e4b722d877fdd5272e665ad665a90a1bc87c88c0a60e9b1ee8ebbd39d132fdfae1f2b143c263dd171",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_010F/7e46b10c-6cfe-462c-a587-5c1cf48a8418/100B-010F-01000A02-ConfLight-LedStrips_0012.zigbee",
     "maxFileVersion": 16779777
   },
@@ -645,7 +645,7 @@
     "imageType": 271,
     "manufacturerCode": 4107,
     "sha512": "34a42cd9185602bf76559425d2e4655ec33c2fe3159a09d866cd3425a0d56535ee9a807b86b21a66083fc7578287538c7e1b8e9aebd53923269aedb99b6090f7",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_010F/0ed8b3ac-0870-486e-9f8b-5ba6e9b035a1/100B-010F-01001700-ConfLight-LedStrips_0012.zigbee",
     "minFileVersion": 16779778
   },
@@ -657,7 +657,7 @@
     "imageType": 272,
     "manufacturerCode": 4107,
     "sha512": "840c55cf8239e7fb3cbe2a055758c3b06adad6316bd09f1d94884b19f2b9ebfa5a844daaaee12713cbd1e8926e227565c50e268e7c70fa6f24ca63af4adf3bf9",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0110/e8a0d0b9-1ce1-4f1a-934f-04ecd04a7080/100B-0110-01000400-ConfLight-Lamps-EFR32MG13_0012_inclBL.zigbee",
     "maxFileVersion": 16778239
   },
@@ -669,7 +669,7 @@
     "imageType": 272,
     "manufacturerCode": 4107,
     "sha512": "4d15669f586c39da05fdfa95506fa085e297e177e5f2e962ce5f8ec2788f1d4488f880c35c2f2a1e0279ffe66272c99d27ca6da5d80512b88fcf50a574647a64",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0110/77cabadf-422e-4b65-a971-b40f6422ca6f/100B-0110-01002602-ConfLight-Lamps-EFR32MG13.zigbee",
     "minFileVersion": 16778240
   },
@@ -681,7 +681,7 @@
     "imageType": 273,
     "manufacturerCode": 4107,
     "sha512": "d7f6adc33b7d1d165e1aab6975825a789e3daa83d8d86fe20b057fb603926548a6eeb6a0af09f20108d87a71aacfed654dc273eb79d4dcf917f254aa13876027",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0111/ad34031b-3c49-420f-9782-f37e205db2a9/100B-0111-01001D00-ConfLight-ModuLum-EFR32MG13.zigbee"
   },
   {
@@ -692,7 +692,7 @@
     "imageType": 274,
     "manufacturerCode": 4107,
     "sha512": "5e7c52ee30fcdca12b875499923ede2078efec650cbbb0a1267874fc88acde456e439b53e6abc69501ed058d6abfeb031f7dec6df888c79b44fc6a7a13927d7b",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0112/fd7eef13-74d9-4920-8315-45adcf652102/100B-0112-01002902-ConfLightBLE-Lamps-EFR32MG13.zigbee"
   },
   {
@@ -703,7 +703,7 @@
     "imageType": 276,
     "manufacturerCode": 4107,
     "sha512": "0f3cef1daeff4f25eed56b82be28c8f8bbb26f13d562aee8fcd86b718b9bcdd8d183b2ad86db7ca75e5ffbeaad32c8c8b1355bfdb3bcac7f4d62f7da574f48cb",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0114/db6d96de-5792-4b3c-a04f-3a773bf45124/100B-0114-01001200-ConfLightBLE-Lamps-EFR32MG21.zigbee",
     "maxFileVersion": 16781823
   },
@@ -715,7 +715,7 @@
     "imageType": 276,
     "manufacturerCode": 4107,
     "sha512": "49a40a59ab73f2222b760319f93243aaf82e2a88eef1e6ec78e5ccc17be24f8d3d6fba5f808837813fa1199154508722989391f7f9e41a2f308fd84573c2ad45",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0114/423ed640-a522-4d4e-92f9-5f99c679195c/100B-0114-01001300-ConfLightBLE-Lamps-EFR32MG21.zigbee",
     "maxFileVersion": 16782079,
     "minFileVersion": 16781824
@@ -728,7 +728,7 @@
     "imageType": 276,
     "manufacturerCode": 4107,
     "sha512": "460470ea628716ede44a160f48a34a6dd6b7288fc23f2525d7a8d9210730800fa7842f8309a7bc36c2584b282072cd50b1b2bf9cb40f9f32e30fd1884dc84542",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0114/28309b46-1ae1-4493-a0bb-f7f26f3ff1ad/100B-0114-01001304-ConfLightBLE-Lamps-EFR32MG21.zigbee",
     "maxFileVersion": 16782083,
     "minFileVersion": 16782080
@@ -741,7 +741,7 @@
     "imageType": 276,
     "manufacturerCode": 4107,
     "sha512": "a4dec4e9d3bb2561218cf370fb9306d85f00464f908a029cf4dc779050fe03fabac041dafe257d6088698c6854dc4326a446b017ef183a06037160bb81e5af33",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0114/b9ca4597-f893-4658-99ad-ed61050ab741/100B-0114-01002502-ConfLightBLE-Lamps-EFR32MG21.zigbee",
     "minFileVersion": 16782084
   },
@@ -753,7 +753,7 @@
     "imageType": 277,
     "manufacturerCode": 4107,
     "sha512": "d2b85f5575c9e5f93966ae3d918a9ace2c725549c7e55c58993217c7bc131ceee20a717912c9b32e697ea840f2c747afdd0a5861b581c4d6bc30416ac26d8360",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0115/84e91e20-7715-4bd0-9a41-2f6dcca94be8/100B-0115-01001402-SmartPlug-EFR32MG13.zigbee"
   },
   {
@@ -764,7 +764,7 @@
     "imageType": 278,
     "manufacturerCode": 4107,
     "sha512": "615c6b6d88bac398c7e01fe857ada5c2a95f2e201cd98f4483fa4220de8c045cefbd7203db006eb7fe5bac4353666bde88987764848e51d452ae6bc854b79a6d",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0116/b1cfb2a9-0bf1-4eb3-b9ec-9ca7fa3f11b8/100B-0116-02001300-Switch-EFR32MG13.zigbee",
     "maxFileVersion": 33559295
   },
@@ -776,7 +776,7 @@
     "imageType": 278,
     "manufacturerCode": 4107,
     "sha512": "aa7c8ffcc189cf32f7a2096fe2e9fdb6c35765d0a08f9558ffff646de8d33b8233c161491be2f959f11e1b60111746406a5f27b0f8aa805589ce784656b5c5df",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0116/37d5e444-b304-423e-a2bb-27e74a263726/100B-0116-02004D27-Switch-EFR32MG13.zigbee",
     "minFileVersion": 33559296
   },
@@ -788,7 +788,7 @@
     "imageType": 279,
     "manufacturerCode": 4107,
     "sha512": "549e1c1e9251d1e2253526a40d18ec0f00f99274bcac73106dda9c3a148921f4cd091eb2fdd0037999f5535f661fdce9b47e306be9483959a9552d989202ec5f",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0117/5cf15788-8127-4557-b873-55a3283d2807/100B-0117-01000B00-ConfLightBLE-ModuLum-EFR32MG21.zigbee",
     "maxFileVersion": 16780031
   },
@@ -800,7 +800,7 @@
     "imageType": 279,
     "manufacturerCode": 4107,
     "sha512": "f9fcd5312ec92d5b0d79f03248c268ef8b5c6a663e666dcb6009a53a75d2d459413414c401596a86e30d5d1686c6e210db9fcaf390271c9202534fdab006b942",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0117/46638111-17d3-47f0-b9c6-67453ac8f299/100B-0117-01000C00-ConfLightBLE-ModuLum-EFR32MG21.zigbee",
     "maxFileVersion": 16780287,
     "minFileVersion": 16780032
@@ -813,7 +813,7 @@
     "imageType": 279,
     "manufacturerCode": 4107,
     "sha512": "3c3b4349089377adc67a209e2241b7817768506588272eecf94692b7fa15c610987496a61619d8b635f7b057be46d66b990a81ff864466066e324ed72f55770f",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0117/a31ccf48-0a8f-4e99-912f-4c3b9fef60f0/100B-0117-01000C04-ConfLightBLE-ModuLum-EFR32MG21.zigbee",
     "maxFileVersion": 16780291,
     "minFileVersion": 16780288
@@ -826,7 +826,7 @@
     "imageType": 279,
     "manufacturerCode": 4107,
     "sha512": "b17faa044694f3b9a3f28653ed0a42441797f60dd390a9507eed8d4baa95368ee4ca9accef6698b0092cc196c99c89129372e2dcba8383473f13d522b02488f1",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0117/a8a50281-4075-4d41-928d-85aec9f4ef33/100B-0117-01001D0C-ConfLightBLE-ModuLum-EFR32MG21.zigbee",
     "minFileVersion": 16780292
   },
@@ -838,7 +838,7 @@
     "imageType": 280,
     "manufacturerCode": 4107,
     "sha512": "9acb1a53c13fedcdf1528cf402971eea7bd7b5c81a8ab4569f86757392fdd5bc305bde30df7c967be63a03ff2a8c961b598ae7eeb561835d56f91be7833fc81b",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0118/de21c7c9-cdfa-4f95-90a6-b0e01bb62e82/100B-0118-01001802-PixelLum-EFR32MG21.zigbee"
   },
   {
@@ -849,7 +849,7 @@
     "imageType": 281,
     "manufacturerCode": 4107,
     "sha512": "b89acc3a4146c033ab96a9f11d07d11f9dcf8e432a357fe063c83065a49e588ec92031bc560462c1e1db2242f49823e1e1528a7660b6970ba576f20135a5b54e",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0119/bc0fab3b-4307-4005-a6b8-ea8beb0f57e9/100B-0119-02002100-Switch-EFR32MG22.zigbee",
     "maxFileVersion": 33562879
   },
@@ -861,7 +861,7 @@
     "imageType": 281,
     "manufacturerCode": 4107,
     "sha512": "0c4bc737a5ea23a9c4fac34f2a2b90308fad1a6ca2e9068519ecaeb623eb3a540e61e96c18b803c46aca968be03d4ad03ed65d70a51f9a2eb16c2dce15ce4beb",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0119/d9e42e82-ed2d-4b98-82fa-f0217e5895d2/100B-0119-02004D27-Switch-EFR32MG22.zigbee",
     "minFileVersion": 33562880
   },
@@ -873,7 +873,7 @@
     "imageType": 282,
     "manufacturerCode": 4107,
     "sha512": "96f12964daa049df95a3087cf96bf765e4f4ddf81877e5d76e9ddc865cb45aa207a27a5288d502c2d4a15a5e95a0934d4fc0c0a893984d0cf7d778c7f269dced",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011A/64f5cda8-1e98-4d34-885b-08ad58b9f702/100B-011A-01000400-SmartPlug-EFR32MG21.zigbee",
     "maxFileVersion": 16778239
   },
@@ -885,7 +885,7 @@
     "imageType": 282,
     "manufacturerCode": 4107,
     "sha512": "e41998d10b6ffdf3276b9acc942cf5cb7468bdae02de337a430b701a817a9c8c5a03a6437e52a263a4b82cd3a0907b60f818ce121f87936b6c3f44812830425c",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011A/c0d186d5-aab0-42bd-a71e-fa29b850aaaa/100B-011A-01000500-SmartPlug-EFR32MG21.zigbee",
     "maxFileVersion": 16778495,
     "minFileVersion": 16778240
@@ -898,7 +898,7 @@
     "imageType": 282,
     "manufacturerCode": 4107,
     "sha512": "6b30e7a6ee5be633cf0b2f7e0695be952bc621bfc431d2ac8e8697a242839ae116dc62f8be1fca97104db9651734b80345751cd0225ee5c21659ef74d4ffedda",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011A/e3332645-c1b2-41c7-b76b-3ce0631401cb/100B-011A-01000504-SmartPlug-EFR32MG21.zigbee",
     "maxFileVersion": 16778499,
     "minFileVersion": 16778496
@@ -911,7 +911,7 @@
     "imageType": 282,
     "manufacturerCode": 4107,
     "sha512": "82ba5d9ce6d0b590e85458b796a1c8d1375d2ac1a24432bc83504f54bf56ca62f96b27b27fe4f867d1ade6c8813045118078aa4b98a6532f8f5a2aeeeaa23c16",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011A/0aafab7f-56c0-4c7b-b0f8-19cfe1f02602/100B-011A-01000F04-SmartPlug-EFR32MG21.zigbee",
     "minFileVersion": 16778500
   },
@@ -923,7 +923,7 @@
     "imageType": 283,
     "manufacturerCode": 4107,
     "sha512": "eab283cabf8d9f55c84b9a0e0ee2da9c6d3eacaebcb3ef8973cb01448df091d437855e7dd6f01e8d8d8bc2db26aa729db52f2c8531d8d0e6d05cce2f4a875d5c",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011B/126cdb96-9758-45c3-98dc-ae35386bc960/100B-011B-02004D23-Sensor-EFR32MG22.zigbee"
   },
   {
@@ -934,7 +934,7 @@
     "imageType": 284,
     "manufacturerCode": 4107,
     "sha512": "aa5b10bdf5910581f1c02e29ef994546d14b7d9be536977d666fcf0af7392db86783478a5d57802e1f320c2235a80d9cf959f6ca2f117c64534b6f24e76292b2",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011C/f8e8feb9-b5b5-4e46-b09d-59c2f2f23efb/100B-011C-02004D23-SwitchModule-EFR32MG13.zigbee"
   },
   {
@@ -945,7 +945,7 @@
     "imageType": 285,
     "manufacturerCode": 4107,
     "sha512": "ca172fda58aac17c731cb55fdf4c4856596917725d1a127c77d64e344b68dbafc063984772e408f94b4dfd8b4a815dc259e48234e55314124b8ca75f4c457c13",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011D/6f9c541e-b1d2-42c2-8098-fc2ce7017cfc/100B-011D-01002504-ConfLight-ModuLumV2-EFR32MG13.zigbee"
   },
   {
@@ -956,7 +956,7 @@
     "imageType": 286,
     "manufacturerCode": 4107,
     "sha512": "77c8e3a4953fa7c1b376f63968df11f7b053a55c895d178cbfaecc5b394684f734fe2f9188abd1afcff7eb96da0daea0803b88397b311a198817bda944543ecf",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011E/42d2db88-6252-4a0f-8c10-ab3fe9a0e8b0/100B-011E-01002404-ConfLight-PortableV2-EFR32MG13.zigbee"
   },
   {
@@ -967,7 +967,7 @@
     "imageType": 287,
     "manufacturerCode": 4107,
     "sha512": "8ec63076c58fb6c3870234aec98ff86ea7043bd25601e155c69f7e864f6bf858e950c76b5bad77386025a79a4fa9a126d87db7ca61e707a0f605fff06b212b3d",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011F/f88abe86-a753-417f-b6e9-772a7a15e84a/100B-011F-01002402-ConfLightBLE-ModuLumV3-EFR32MG21.zigbee"
   },
   {
@@ -978,7 +978,7 @@
     "imageType": 288,
     "manufacturerCode": 4107,
     "sha512": "4c61e5be6488454554dbc62006d63111a121ad864c42827d7dba634630ade6b3098167b92b271a0ff3793223943df4ed2cf08d55dfdc3c56b7a91b552d8a8912",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0120/ca5124f9-b9b5-4474-ba8d-3f431d713eb7/100B-0120-01002402-ConfLightBLE-PortableV3-EFR32MG21.zigbee"
   },
   {
@@ -989,7 +989,7 @@
     "imageType": 289,
     "manufacturerCode": 4107,
     "sha512": "3ea0778f4eb4c2494e0b81d7ef85bd957fece8ca051289bd99dc5de1a6fb344d92ae1f481be64a516f97f72a6e947d0c0d88408c6b0945bda63dd81e7adc6618",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0121/c4cba7cc-7784-4b20-88db-df8e82ddb487/100B-0121-02004D27-Switch-EFR32MG22-40xf.zigbee"
   },
   {
@@ -1000,7 +1000,7 @@
     "imageType": 290,
     "manufacturerCode": 4107,
     "sha512": "12c72c104444768ad8af52eb699e51f72726da24338fa6b24df0a0f2bd042a5cb4e193e838b9c38826d1debe81f612e27130e5b5dd75de31a9d55ebd99ec4045",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0122/b839c65f-9ee0-4cb5-94e4-8063b92bcb01/100B-0122-02004D23-SwitchModule-EFR32MG22.zigbee"
   },
   {
@@ -1011,7 +1011,7 @@
     "imageType": 291,
     "manufacturerCode": 4107,
     "sha512": "a4317039a4fa26845b743d8ab2aa037b3589b4506e35e9462f1a1475351ab7eee74c3705ea9b1bff92d7f76cb72011a13d92423d65bebfbcc7524b57e0a04e29",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0123/567ce2cd-671c-4072-8485-2b19d250e9c7/100B-0123-01000C02-PixelLumXL-EFR32MG21.zigbee"
   },
   {
@@ -1022,7 +1022,7 @@
     "imageType": 293,
     "manufacturerCode": 4107,
     "sha512": "a2a0076275a1dcdb94a9bea8c1591209f31f76fe847d5fd46456dad63247d0c302e438776c179dcc86f93471b3965e884f3455c06c332313fdc408df71a58c11",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://firmware.meethue.com/storage/100b-125/33571585/17803020-a40e-4015-b9e3-3454e43998bb/100B-0125-02004301-ContactSensor-EFR32MG22.zigbee",
     "maxFileVersion": 33571584
   },
@@ -1034,7 +1034,7 @@
     "imageType": 293,
     "manufacturerCode": 4107,
     "sha512": "0e9f6fa8f476e0f2e7a8b7bad8066ffc65368ae753b0e4df7061f0b7c750c7a1f9241e69c522f43ef3268db45eb3ffdcf82560d6a2c33556c0e9f12001420762",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0125/7ef867a4-88e3-4aae-a94a-3f2940081717/100B-0125-02004D23-ContactSensor-EFR32MG22.zigbee",
     "minFileVersion": 33571585
   },
@@ -1046,7 +1046,7 @@
     "imageType": 295,
     "manufacturerCode": 4107,
     "sha512": "9d7e340b79e0a82e16a7873760762e374be8b96267c4f643aedfdac7f4710bbce66beef51b1d4e353743a09cdbb22474508f419f124aae937d2bdd71cbc780d3",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://firmware.meethue.com/storage/100b-127/16780546/96200b09-9d10-4272-adeb-b89203fffc41/100B-0127-01000D02-MSD-EFR32MG21.zigbee"
   },
   {
@@ -1057,7 +1057,7 @@
     "imageType": 260,
     "manufacturerCode": 4107,
     "sha512": "eb9e81b28ea8128831c0f656e65be2821b6d06207bd44adbc31b050ed41e3656edc10e1c0a27cf73a2817c257208f9002c3e219913903ecdaacf7857f799b001",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0104/33cbfd3d-3b58-43e2-a6a0-1e6fe50f2bee/ConnectedLamp-Atmel-Target_0012.sbl-ota",
     "minFileVersion": 1107326256
   },
@@ -1069,7 +1069,7 @@
     "imageType": 260,
     "manufacturerCode": 4107,
     "sha512": "d2bf330b9a23114efb6a613ccefce691e4a67a98175033e65d3eaf6841312b5a542bd538ae19c06c3804aa06224d35acc184f4b37a6198b457df2a173a490f21",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0104/631d2194-554e-4016-b954-f3c226482f04/ConnectedLamp-Atmel_0104_5.130.1.30000_0012.sbl-ota",
     "maxFileVersion": 1107326255
   },
@@ -1081,7 +1081,7 @@
     "imageType": 256,
     "manufacturerCode": 4107,
     "sha512": "c63a1eb02ac030f3a76d9e81a4d48695796457d263bb1dae483688134e550d9846c37a3fd0eab2d4670f12f11b79691a5cf2789af0dbd90d703512496190a0a5",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0100/2dcfe6e6-0177-4c81-a1d9-4d2bd2ea1fb7/ConnectedLamp-TI-Target_0012.sbl-ota"
   },
   {
@@ -1092,7 +1092,7 @@
     "imageType": 264,
     "manufacturerCode": 4107,
     "sha512": "5c0736a0d4f191a214a209fca6a1984a5ca2caa073b79dccc3ea62cfb0dd4b6755d92770f49bdc904ddafaa586a65d8b71160f74420ff937007f79f5cc477389",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0108/a2470745-062a-4159-adc5-5162080aacb5/LivingColors-Atmel-Target_0012.sbl-ota",
     "minFileVersion": 1107326256
   },
@@ -1104,7 +1104,7 @@
     "imageType": 259,
     "manufacturerCode": 4107,
     "sha512": "f1c9b5f0cc779bcf01fb1f7e5bffc0112aa82e60972dad9264f87484a571d13710572c2f5fedf1dd2b5deb62fa45d4c0e41d107e2fd2fb544fb5a9235d21ee3a",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0103/e14480ff-2661-4abb-8dfd-275b77d876c2/LivingColors-Hue-Target_0012.sbl-ota"
   },
   {
@@ -1115,7 +1115,7 @@
     "imageType": 264,
     "manufacturerCode": 4107,
     "sha512": "7d6166daf46ad68275ada764d17d9fde78b364c4ebb0f81664fb8159efc81a225790d5f670e036489be80fa2a9fedf92201990336559d2299c16faeb396a46b6",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0108/fb2b4e6e-f8c4-44b0-88cb-aac2e88c9fa0/LivingColors-Target_0108_5.130.1.30000_0012.sbl-ota",
     "maxFileVersion": 1107326255
   },
@@ -1127,7 +1127,7 @@
     "imageType": 267,
     "manufacturerCode": 4107,
     "sha512": "9c5b28be12dd8299774f0d0515131156ee9882f683537553fcf878198b4da198270c79a5dab0cfb81b80e35db055dff850835da4e069d27a7e8eb2de0d461d1b",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_010B/1cfec25a-f2f5-4e84-a80f-96548a95d6c3/ModuLum-ATmega_0012.sbl-ota",
     "minFileVersion": 1107326256
   },
@@ -1139,7 +1139,7 @@
     "imageType": 267,
     "manufacturerCode": 4107,
     "sha512": "903dc359ddab530136e2aced646633627555a4317696f9a1c61300ff2006109e316443f7807b03397021e9162698dc9ba7fcbb3749f6f5a83883b9aafc78eb10",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_010B/e3d57ccf-94b9-4786-8b3f-569c5c8883f8/ModuLum-ATmega_010B_5.130.1.30000_0012.sbl-ota",
     "maxFileVersion": 1107326255
   },
@@ -1151,7 +1151,7 @@
     "imageType": 269,
     "manufacturerCode": 4107,
     "sha512": "ba7cc0e3632c1f6c50ccb6f3a33ee44947de643425743c35657ce34dae3c0c9c45d48b05479b1183fcb9f1572df68d9d5b8c6f2f0a86c72d095773e817e8147f",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_010D/fa14f094-f99f-497d-9bd5-cc2742b2cb69/Sensor-ATmega_0012.sbl-ota"
   },
   {
@@ -1162,7 +1162,7 @@
     "imageType": 0,
     "manufacturerCode": 4420,
     "sha512": "eb1e76825aca6a6418042d71821921d4c073aa1ada0d52eaffd967ce2ccba7a5dda07a6caab70f19b3a2f9630d43b055c06d16050101b655413ba271375bea57",
-    "otaHeaderString": "EBL Z3SwitchSoc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL Z3SwitchSoc",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_1144_0000/04071b69-217b-4d73-8cf3-367ed2dc7ca8/Superman_v3_08_ProdKey_3080.ota"
   },
   {
@@ -1173,7 +1173,7 @@
     "imageType": 265,
     "manufacturerCode": 4107,
     "sha512": "6bec6b6dce7ef9bb47c4467643222871788256d5c3f0aa88ded80be24fc002dbdda525ca2cafa78b996ff7fe0c18d7c9194288e4f6b40f0f37d147bc1724dd4e",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0109/3a1c8cf8-3f4c-4464-93f0-24cc7f67f0d7/Switch-ATmega_0012.sbl-ota"
   },
   {
@@ -1184,7 +1184,7 @@
     "imageType": 261,
     "manufacturerCode": 4107,
     "sha512": "aacf086c482e149e916a12a344d0d2a2b1489e47f5d4d5ef9d9ebb308b976c5d8d266a19792a53ee64a108d8f39b56c800815191d4454311124fe85fe32392a2",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0105/a74b4fe6-805b-4113-8f08-2f6585cb8f5d/WhiteLamp-Atmel-Target_0012.sbl-ota",
     "minFileVersion": 1107326256
   },
@@ -1196,7 +1196,7 @@
     "imageType": 261,
     "manufacturerCode": 4107,
     "sha512": "a3492bec9fd9b3149be9135ea9175d6161617188c04428230bbea161660c0cef2f9c83ecc185b758e1337d4f99e08f3978fd9102eec67843bac66e6dbc1e39a9",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0105/6b0b2e69-652d-4941-9da9-a4e7ff0fc70c/WhiteLamp-Atmel-Target_0105_5.130.1.30000_0012.sbl-ota",
     "maxFileVersion": 1107326255
   },
@@ -1208,7 +1208,7 @@
     "imageType": 10243,
     "manufacturerCode": 4476,
     "sha512": "fcdcc6198cd5f41d3602000207fa4a4c7678279dce4c2e8467d2044293e27d8d9d63e0aa71b5125af62a74b599bfb0dd28645961fb034c803722b732d20802d0",
-    "otaHeaderString": "EBL tradfri_wrgb\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_wrgb",
     "originalUrl": "http://fw.ota.homesmart.ikea.net/global/GW1.0/01.21.031/bin/10035515-TRADFRI-bulb-cws-2.3.093.ota.ota.signed",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1220,7 +1220,7 @@
     "imageType": 16645,
     "manufacturerCode": 4476,
     "sha512": "c656737a4fd3464ed09d47887cde2b7390b13fe6423c06d5ceba5aa92d40dade89c49b4feabf89546585936c40543113bfcf720a4b09158e7e5fa924f7b385b8",
-    "otaHeaderString": "GBL zingo_lds_stoftmoln\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo_lds_stoftmoln",
     "originalUrl": "http://fw.ota.homesmart.ikea.net/global/GW1.0/01.21.031/bin/10082264-zingo_lds_stoftmoln-1.1.7.ota.ota.signed",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1232,7 +1232,7 @@
     "imageType": 40766,
     "manufacturerCode": 4476,
     "sha512": "76f16f4c2ca48a2b6a66693c3a2d4f85d2f52ff440cc09a565b5856d46a872435b28c5a9b6746d50cb2425555db9bdf41ae05e1a17b0292095198af53552e5eb",
-    "otaHeaderString": "GBL inspelning_smart_plug_soc\u0000\u0000\u0000"
+    "otaHeaderString": "GBL inspelning_smart_plug_soc"
   },
   {
     "fileName": "mgm210l-light-cws-cv-rgbw_release_prod_v268572245_3ae78af7-14fd-44df-bca2-6d366f2e9d02.ota",
@@ -1242,7 +1242,7 @@
     "imageType": 10242,
     "manufacturerCode": 4476,
     "sha512": "d00cb8207813feb220c7a907644304b1cb39e4ee239de835c5c73e3bc41a0baaea2d58823ec14ed6887ee442e7014c4617d3c3354dedd11184f83cd26f9dfd8b",
-    "otaHeaderString": "GBL Signed OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL Signed OTA",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/mgm210l-light-cws-cv-rgbw_release_prod_v268572245_3ae78af7-14fd-44df-bca2-6d366f2e9d02.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1254,7 +1254,7 @@
     "imageType": 6456,
     "manufacturerCode": 4476,
     "sha512": "39a5d1f8a626c02f3648799b27fb2367e246af3a28a798c90b5374b715f637a13c47fba2ce288ea64a7fc8e17ae98fc1ed64daf05d3629b3f56ad8eee0bd9100",
-    "otaHeaderString": "GBL motionsensor_lds_mg21a\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL motionsensor_lds_mg21a",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/motionsensor-lds-mg21a_release_prod_v16777316_3a00064a-cc29-4aac-bdb6-c4fa1fb445d5.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1276,7 +1276,7 @@
     "imageType": 4367,
     "manufacturerCode": 4476,
     "sha512": "995c25c09706dd39498d1adb6f0aca700c193dc1d5b18069f2057f5d2f05096527731330278f4ca15350d4e72489e0349e285af5d5befae25c5e992c847a50b6",
-    "otaHeaderString": "GBL zingo_ikea_vindstyrka\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "GBL zingo_ikea_vindstyrka"
   },
   {
     "fileName": "rodret-dimmer-soc_release_prod_v16777303_0a78457a-950c-4903-bfd1-67902aa66cf9.ota",
@@ -1286,7 +1286,7 @@
     "imageType": 4557,
     "manufacturerCode": 4476,
     "sha512": "0f248c6036c323f5d56158b9451d1e73b1a7935b8628bdff6a58590ce2e6625b4bdd0772c5a1318eb8302ab6601170dfeed1ebc0e8eafe6de686e5b98f56c883",
-    "otaHeaderString": "GBL rodret_dimmer_soc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL rodret_dimmer_soc",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/rodret-dimmer-soc_release_prod_v16777303_0a78457a-950c-4903-bfd1-67902aa66cf9.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1298,7 +1298,7 @@
     "imageType": 15112,
     "manufacturerCode": 4476,
     "sha512": "2a6553362120c82385f9d49666907b8b194a43e4420bbad251c9d31f09ee6a4a583fab0f374b571f3b3f29a50614f956be7ae23147e85a26a5602dbbf9107671",
-    "otaHeaderString": "GBL rodret_shortcut_soc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL rodret_shortcut_soc",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/rodret-shortcut-soc_release_prod_v16777249_d89ffc33-55d1-4d47-acac-42365e5d9dd8.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1310,7 +1310,7 @@
     "imageType": 10241,
     "manufacturerCode": 4476,
     "sha512": "faa374df605e1708c1e2b48568ca657c1a3e2dc43f72991ebad0fa869d23e613b2faeb3e124d9a364b29cb4ee179b04824bd54dab48a0f5d67c60cea14c5be5d",
-    "otaHeaderString": "EBL tradfri_wrgb\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_wrgb",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-bulb-cws-zll_release_prod_v587753009_ec8b1193-0fa2-440e-b921-2412a8688b74.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1322,7 +1322,7 @@
     "imageType": 8449,
     "manufacturerCode": 4476,
     "sha512": "d383dc0ad22c96e6876298758979f14917b9972aa68b18e772b103a08969f262ed71d30daed9de40d486f13b8a0df686340b946bafe23621e1fb1ce2866d0572",
-    "otaHeaderString": "EBL tradfri_light_basic\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_light_basic",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-bulb-w-1000lm_release_prod_v587810353_5a161508-742d-4eab-8761-286c80d116eb.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1334,7 +1334,7 @@
     "imageType": 8706,
     "manufacturerCode": 4476,
     "sha512": "c8436256d91deb8d88218b57d1d365906ad73320b6db34b22ea318a4c712b16588b059dc0899bb3cf879de303e9a76ddbc572334bcf1a16ed0269d75bf40bf4f",
-    "otaHeaderString": "EBL tradfri_light_1000ml\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_light_1000ml",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-bulb-ws-1000lm_release_prod_v587814449_2b13625e-17a8-40d9-bad3-47a9a96ab002.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1346,7 +1346,7 @@
     "imageType": 8705,
     "manufacturerCode": 4476,
     "sha512": "b1ed830781ba1dc18c6bf41adf02b6653a918f3ed05396110e6054b4a6c2fdca2a9ff39e82e0776339f63aaeaefaf5393e4b6a87a6d3bfa7a68cd222b26a4007",
-    "otaHeaderString": "EBL tradfri_light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_light",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-bulb-ws-e14_release_prod_v587757105_963ac72a-97be-4f7e-b12c-46759bb91d6e.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1358,7 +1358,7 @@
     "imageType": 8707,
     "manufacturerCode": 4476,
     "sha512": "8da9e1bc6cee95cad20acb6d4a60cfb73b3f213f935451c66ed1d165fa0350de662856f8eaf1611723cf22dd03f91e6b6582cb8285edd63ec2a52c9d35b1b6bc",
-    "otaHeaderString": "EBL tradfri_light_gu10\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_light_gu10",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-bulb-ws-gu10_release_prod_v587757105_25ac125d-5723-4b92-aa02-404fd5008a55.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1370,7 +1370,7 @@
     "imageType": 4487,
     "manufacturerCode": 4476,
     "sha512": "6fded116c93dc2bb20443f11bbc11ba84bd9803255f2ed4ae076ff6661f840b7c3e8e6b67a1671625f081faf8613f0be87b5764c57163a1c2585d777d2481f77",
-    "otaHeaderString": "GBL GBL_tradfri_connected_blind\u0000",
+    "otaHeaderString": "GBL GBL_tradfri_connected_blind",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-connected-blind_release_prod_v604241939_89e61475-8999-4074-842a-e04efac9c857.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1382,7 +1382,7 @@
     "imageType": 4353,
     "manufacturerCode": 4476,
     "sha512": "83d8427b1fbc4701673185fc02c846680ce83b9270bb75896377469c69eb1be37648fdf019a39b340a1f928a1ece21e394dc94b926245b3aa5a59c7147f73a3b",
-    "otaHeaderString": "GBL GBL_tradfri_control_outlet\u0000\u0000",
+    "otaHeaderString": "GBL GBL_tradfri_control_outlet",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-control-outlet_release_prod_v587765297_20061876-85d6-4b39-8c9c-eb95620baa97.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1394,7 +1394,7 @@
     "imageType": 4545,
     "manufacturerCode": 4476,
     "sha512": "513c5a4bff7d64c014d11c8f8ca776e57b73ee6e18227be80be179e513a853e2eccda5acedd294f94a2f2e123ccc41d64d871f29c5e88cbc2be9d6350b6ffc77",
-    "otaHeaderString": "EBL tradfri_controller\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_controller",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-controller_release_prod_v604241925_abef4451-762a-4ef9-8c11-dfd88c3e98f7.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1406,7 +1406,7 @@
     "imageType": 16902,
     "manufacturerCode": 4476,
     "sha512": "98d8be5b4dcd9692cb6ff87531513023c0116cb9137c5690105ce2077765f35ae2651bdd2aa80ce0363f6db4ef3b9795449252c6c0ff8a8b0e6e05789fdb03be",
-    "otaHeaderString": "GBL GBL_tradfri_cv_cct_unified\u0000\u0000",
+    "otaHeaderString": "GBL GBL_tradfri_cv_cct_unified",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-cv-cct-unified_release_prod_v587757105_33e34452-9267-4665-bc5a-844c8f61f063.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1418,7 +1418,7 @@
     "imageType": 4554,
     "manufacturerCode": 4476,
     "sha512": "69b8a35e926eab95831df7ddf91f607cf3462fe02d01eab77ad2f63e0dde5be2ac118bcd136c41d383cf74d50fc26911561649b042c997d7c3043a20e22ba7e4",
-    "otaHeaderString": "GBL GBL_tradfri_dimmer\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL GBL_tradfri_dimmer",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-dimmer_release_prod_v604241925_ecbb4451-ce85-4e6c-ab9f-e7ce32cd0c1e.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1430,7 +1430,7 @@
     "imageType": 16898,
     "manufacturerCode": 4476,
     "sha512": "13109c4d517f16aa069af63c3c8257767a98c22fd21dd964e54c36deabb62494b2ee5fd2cbda1e925389277db9deadd95a0eaa173b0f6f35aee65159a97dcff3",
-    "otaHeaderString": "EBL tradfri_light_hp\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_light_hp",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-driver-hp_release_prod_v587757105_b42c57bf-cb9c-478c-8327-5812a3286a64.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1442,7 +1442,7 @@
     "imageType": 16897,
     "manufacturerCode": 4476,
     "sha512": "5a7718b7c56e00cae0dc2396a339dde9d837f0ea0d023d653d93044eaf8841a9799f64301d09b3ad7fa0e6b81b76ca4b704291a30a8943c79f14ff0bfa05554e",
-    "otaHeaderString": "EBL tradfri_light_lp\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_light_lp",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-driver-lp_release_prod_v587757105_b28cda41-22d2-446b-b3bf-5ca11d866719.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1454,7 +1454,7 @@
     "imageType": 16649,
     "manufacturerCode": 4476,
     "sha512": "9e2560406937f8e342c391ef18ad8aefdea62adcc0c59fc163c3daf2f7dd91626e47466388a8a7b7e85ac0508d0eb6bce4891d1622fde52f508764921e3cd79d",
-    "otaHeaderString": "GBL zingo_ikea_driver_hwpwm_ww\u0000\u0000",
+    "otaHeaderString": "GBL zingo_ikea_driver_hwpwm_ww",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-driver-zingo_release_prod_v16777220_1fd2b92c-45c5-44d0-97c5-5c71c2ecb8d2.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1466,7 +1466,7 @@
     "imageType": 16643,
     "manufacturerCode": 4476,
     "sha512": "e9ca743c2309cee9f12b481ac959da0d0ad095f009049c133c003447095a2295fac56969a682070cea75037e74ef37df7b93e39eda1fc4a3f4efe15fa9bace21",
-    "otaHeaderString": "GBL GBL_tradfri_light_unified_w\u0000",
+    "otaHeaderString": "GBL GBL_tradfri_light_unified_w",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-light-unified-w_release_prod_v587806257_147c8812-e7f3-4999-b7eb-3da91009ab65.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1478,7 +1478,7 @@
     "imageType": 4552,
     "manufacturerCode": 4476,
     "sha512": "178bc4070db85787b2a8bc154a79ed10feb0a3dc06debc61f01f3e870effd36763569e601b75a2f64a9f5a409387dd5e18b7675e280966cdb0e57db0590c0cbc",
-    "otaHeaderString": "GBL GBL_tradfri_motion_sensor2\u0000\u0000",
+    "otaHeaderString": "GBL GBL_tradfri_motion_sensor2",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-motion-sensor2_release_prod_v604241925_8afa2f7c-19c3-4ddf-a96c-233714179022.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1502,7 +1502,7 @@
     "imageType": 4550,
     "manufacturerCode": 4476,
     "sha512": "8527aa46afbf93cfaec68845cfc5092ca533b87ef0d162741eee82b32185a9d2966235edaae8127d9ee81a70f5247a23d75907b2387f520d797f3da1e9fdc3db",
-    "otaHeaderString": "GBL GBL_tradfri_shortcut_button\u0000",
+    "otaHeaderString": "GBL GBL_tradfri_shortcut_button",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-shortcut-button_release_prod_v604241926_56f5d8d1-78b1-4088-afc1-05d3b7e3314b.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1514,7 +1514,7 @@
     "imageType": 4354,
     "manufacturerCode": 4476,
     "sha512": "f5166c7fb478b574269092b1086424cbc726bb05fa5512d5dcbb62f53b0fa2f184533d9467977e1e6ebc83e1ec6998b5097bfb65238b226b24a13ab54a9de731",
-    "otaHeaderString": "GBL GBL_tradfri_zigbee_repeater\u0000",
+    "otaHeaderString": "GBL GBL_tradfri_zigbee_repeater",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-signal-repeater_release_prod_v587753009_3ce8f096-bd12-4b2c-b66e-51dc9f2637dc.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1526,7 +1526,7 @@
     "imageType": 16900,
     "manufacturerCode": 4476,
     "sha512": "a1ae0dd420adf21515a772631117c867712998d123c4c4a2c4655038aa5fc6104fc1cabc01fa18b8c8a9522efda86a53f2cfbc9557976a30b72c0068c4ded7d5",
-    "otaHeaderString": "GBL GBL_tradfri_sy5882_bulb_ws\u0000\u0000",
+    "otaHeaderString": "GBL GBL_tradfri_sy5882_bulb_ws",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-sy5882-bulb-ws_release_prod_v587814449_185b3c4d-da1b-4867-8c16-2cee1fc5c11d.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1550,7 +1550,7 @@
     "imageType": 16901,
     "manufacturerCode": 4476,
     "sha512": "5cf9948f9a048dcd9d4dbbdc9ef0f9ff64687c3d64fc8077b6368ee3c27ede31916f3132d4f2e86aadd13f1d8ba145cb90ff166e7b4b59951317d13747b3c2f3",
-    "otaHeaderString": "GBL GBL_tradfri_sy5882_unified\u0000\u0000",
+    "otaHeaderString": "GBL GBL_tradfri_sy5882_unified",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-sy5882-unified_release_prod_v587757105_d478807c-f16e-4989-a948-82818fb545b9.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1562,7 +1562,7 @@
     "imageType": 16641,
     "manufacturerCode": 4476,
     "sha512": "ab7efe310564f5e48bd122281092fe6e9be727a78825308d5597e5ac30995381d9b911e7f984ebccba2156da35450ec4c85854d51349e09acee23bb01bddc97a",
-    "otaHeaderString": "EBL tradfri_light_ansluta_basic\u0000",
+    "otaHeaderString": "EBL tradfri_light_ansluta_basic",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-transformer_release_prod_v587753009_17d32c23-151f-44cb-a947-4c13a78f36e6.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1574,7 +1574,7 @@
     "imageType": 4546,
     "manufacturerCode": 4476,
     "sha512": "d3691fa7980da249e6bd8ad416ca3ccec7e385ebcb49ed24408e985a4e5561a9bcd71918666c37e4f72f6aed672121b1fec98f2ee8718b69a5d575d8a5d02e6c",
-    "otaHeaderString": "EBL tradfri_switch_basic\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_switch_basic",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/tradfri-wireless-dimmer_release_prod_v587367985_87ff9a75-c4e3-4999-a654-09bb8638f4cc.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1586,7 +1586,7 @@
     "imageType": 4352,
     "manufacturerCode": 4476,
     "sha512": "cd2f88f3f47f459218dd23d1317e76f413cea8a4eedee047a7a6627a595e742f47ec2783eeb2b33e634435cda3f219fa7b540dde6d67876f05d3fdf6feb636d2",
-    "otaHeaderString": "GBL tretakt_smart_plug_soc\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL tretakt_smart_plug_soc",
     "originalUrl": "http://fw.ota.homesmart.ikea.net/global/GW1.0/01.21.031/bin/tretakt_smart_plug_soc-0x1100-2.4.25-prod.ota.ota.signed",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1598,7 +1598,7 @@
     "imageType": 51017,
     "manufacturerCode": 4476,
     "sha512": "9563658eca45bba7f6a91528694b8e6db4e78b8b72160310120bc11b48f76708d53328dfe6a0b26797a11ad4f1c4cae832515b9fb4c4135735bf0959e641b6d3",
-    "otaHeaderString": "GBL zingo_jetstrom_cws\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo_jetstrom_cws",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-jetstrom-cws_release_prod_v16777268_023f19b9-f55b-4c94-a3fe-00c97755eb78.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1610,7 +1610,7 @@
     "imageType": 4357,
     "manufacturerCode": 4476,
     "sha512": "95d187ca0a3c4edba376571ea9631a3c04f0518b3593d83863b1f40ce5f3a51f9aa7459091f59e5e7c7e6f6cbea7d476d7d396424336bf96bd0e8586595f0cca",
-    "otaHeaderString": "GBL zingo_lds_bulb_jetstrom_ws\u0000\u0000",
+    "otaHeaderString": "GBL zingo_lds_bulb_jetstrom_ws",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-jetstrom-ws_release_prod_v33816584_33813e5d-0cc9-4b4a-9e93-9000ee44cbe4.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1622,7 +1622,7 @@
     "imageType": 8708,
     "manufacturerCode": 4476,
     "sha512": "8053c97e5a587a806f24a2006eecc7ad43a968052d58b62b968bfb5fdf38c40f12e24a0908412cf8cc9cb59d2e92488ff6424fda4bdd0175f756a42c6724979e",
-    "otaHeaderString": "GBL zingo_kt_bulb_hwpwmcs_ws\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo_kt_bulb_hwpwmcs_ws",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-kt-bulb-hwpwmcs-ws_release_prod_v16842784_32dc5ff1-4fa4-4960-a847-5e548a81047c.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1634,7 +1634,7 @@
     "imageType": 4555,
     "manufacturerCode": 4476,
     "sha512": "b9bdc4022897cfcd826dd8f537bcef0a83929d3334f9838498e45fa81265ba2bc5182df0f022f92e283cab0dfaea897a3e2452ddf9d7b8a32405aa327b652973",
-    "otaHeaderString": "GBL zingo_kt_styrbar_remote\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo_kt_styrbar_remote",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-kt-styrbar-remote_release_prod_v33816598_c00d5422-e816-48ec-87a6-40198661d2d5.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1646,7 +1646,7 @@
     "imageType": 8450,
     "manufacturerCode": 4476,
     "sha512": "cfd6b7b521b41aefd57eb0e474d07f22fad59aae07d2d23db8c0d1f59f5c7354b80162a2f95e3310a8f6923475a6e215a450b31db6551c0adba4ce8603dae9c6",
-    "otaHeaderString": "GBL zingo_lds_bulb_hwpwm_ww\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo_lds_bulb_hwpwm_ww",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-lds-bulb-hwpwm-ww_release_prod_v16842756_529d7965-cee3-4c32-bd28-e5dd17ddc256.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1658,7 +1658,7 @@
     "imageType": 8709,
     "manufacturerCode": 4476,
     "sha512": "58bb981b05c1a1ba4c86f8c02facf1474a2d7877fd7f7155e15e7a03a91a38f5b070e27fcf1e53fd238bafb12b771e869655e864fd2385e2a83b5282055de8c9",
-    "otaHeaderString": "GBL zingo-lds-bulb-hwpwmcs-ws\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo-lds-bulb-hwpwmcs-ws",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-lds-bulb-hwpwmcs-ws_release_prod_v65554_5d50205c-63c3-426d-bfba-4839c4b55bba.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1694,7 +1694,7 @@
     "imageType": 16644,
     "manufacturerCode": 4476,
     "sha512": "e06f08a6091d7c5712d8c99997b7aa81cac20386ad4ae08b55ca75127e9156e4cddebfdf6cb7f71d6a3b64c672a550f7e46488c81a5281aa135793680221b026",
-    "otaHeaderString": "GBL Signed OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL Signed OTA",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-sigma-driver-silverglans-ww_release_prod_v65569_73466dc4-1320-4242-add6-717432538a77.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1706,7 +1706,7 @@
     "imageType": 8710,
     "manufacturerCode": 4476,
     "sha512": "8458fac2bb64a28167c0c9b95d19d953a77e5ba839a218cd1eea338909d3e25dd204db0a3b43466182d71732c0d99ce6aa6a55b5f48b4207a999528daa371329",
-    "otaHeaderString": "GBL zingo_ws_soc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo_ws_soc",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-ws-soc_release_prod_v50331683_f909cf22-3452-47e3-b8b2-c59d82102e17.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1718,7 +1718,7 @@
     "imageType": 8704,
     "manufacturerCode": 4476,
     "sha512": "079742b178c6a667e8965466fd9ff7554864a40c761a0dbc13cae68900088bf49883ab27f466ed4a47201f8fda697763ff354d0d0edfc85af6f8b417a74852c8",
-    "otaHeaderString": "GBL zingo_ws\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo_ws",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-ws_release_prod_v50331681_969bee21-eca6-4f10-a4c0-9685c0cd5d52.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1730,7 +1730,7 @@
     "imageType": 8448,
     "manufacturerCode": 4476,
     "sha512": "346c769cb5a81638d38391afd8fa8acdbb3fbbe3f43994c6a09fc5551b551b7a84e13b27823cbe533d28a860b0286bd3fa47b768719d1568c5deb6ef1aec1706",
-    "otaHeaderString": "GBL zingo_ww\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo_ww",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-ww_release_prod_v16777282_a39f1e76-af87-4f04-bd7f-0faf71baf3e4.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1742,7 +1742,7 @@
     "imageType": 10245,
     "manufacturerCode": 4476,
     "sha512": "c41e5f5c5caba112c83765055ace9794c2a53f92a7574727d94cfcef353abf6c84e69d53ffbeedb9d83205d534a272d34b9311a6d19e62a6e0cd19d7070af292",
-    "otaHeaderString": "GBL zingo_cws\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo_cws",
     "originalUrl": "http://fw.ota.homesmart.ikea.net/global/GW1.0/01.21.031/bin/zingo_cws-0x2805-1.0.44-prod.ota.ota.signed",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -1754,7 +1754,7 @@
     "imageType": 265,
     "manufacturerCode": 4454,
     "sha512": "63c1f5676ed175002c18466970f434f71ffc729f758f4d2b001fbbbc08d8241a13e710e310da5afdc42d83baf9be9dabd4df2581c2d6b70c20ca81d802a1f084",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-010a-17103685-rb267-1.7.16.ota",
@@ -1764,7 +1764,7 @@
     "imageType": 266,
     "manufacturerCode": 4454,
     "sha512": "07213630168af80893093522bd122c521e6f8b08d44ec7d566adf267a7204e2ea3c32a1c3120980460d57ab5cdfdab753527c0e78f93edf51725ad8732656e3d",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-010b-17103685-rb243-1.7.16.ota",
@@ -1774,7 +1774,7 @@
     "imageType": 267,
     "manufacturerCode": 4454,
     "sha512": "60fc7967ef0702d4a06ce3ce3cbeae6e9388d495c8506f849d2143b1c8f2ba181ea6d20d050b5dfc87e25f8d34e8aedafbced076dfdf3bd00598a74c9b74fc43",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-010d-17103685-rf262-1.7.16.ota",
@@ -1784,7 +1784,7 @@
     "imageType": 269,
     "manufacturerCode": 4454,
     "sha512": "9c856d7f1aa28af576849cdb46c8e4d175f9ca3fc5d974b34d332e1ea2ab2c744f3ab9a5711a34d2f1a217b2b25f1363be59273bac7fbaeb20c5e5f101e0f876",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0112-10096610-RS_226v1-upgradeMe.ota",
@@ -1804,7 +1804,7 @@
     "imageType": 277,
     "manufacturerCode": 4454,
     "sha512": "e6dbd3ab1d4b457cd6d8f102835ecb569364455de465d4068ea927551111137ed68da30d4b61c4c9908cd6cb701487cf50fb316ac2b1113c901daad5c13bd7c6",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-011A-20086A30-RS_229_T-upgradeMe.ota",
@@ -1814,7 +1814,7 @@
     "imageType": 282,
     "manufacturerCode": 4454,
     "sha512": "0d21ed79d6c102790ec2017ec768c334cf175f381df3556505f6aa078d3b26373411b4ee0b656fb505923a178c94e13f4c6c0c2f0c09b3e72d227113aceed55f",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-011B-10116610-RB_245_v2-upgradeMe.ota",
@@ -1834,7 +1834,7 @@
     "imageType": 284,
     "manufacturerCode": 4454,
     "sha512": "74994baf707f7300353c63ab595a33ba4f1f8a8cb3a58b04d6fa8b68098e36e8cc863881c5491d480d037960ce8c0ce8543fafe74c409de9ffca64987cc893cc",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-0120-20026A30-RF_263-upgradeMe.ota",
@@ -1844,7 +1844,7 @@
     "imageType": 288,
     "manufacturerCode": 4454,
     "sha512": "83410df888984666b83ecf87ee4fc0059082ac30acfbbadd8a3cdce62302501cc927aabd631dc741f3e351526caac506e7b80d5b26601c36b7064a1210ed2064",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-0121-20026A30-RF_265-upgradeMe.ota",
@@ -1854,7 +1854,7 @@
     "imageType": 289,
     "manufacturerCode": 4454,
     "sha512": "c2f46b6db03e16664479f0293e7dfa88b6d92f3620bc277e86bf5e75f552fe7077f64fa95899748cd140f9a073c567c69e5fc5591e2377409fad2e0ae819b0ee",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-0122-20026A30-RF_261-upgradeMe.ota",
@@ -1864,7 +1864,7 @@
     "imageType": 290,
     "manufacturerCode": 4454,
     "sha512": "3ddad977b5bfe38a842a0e1ab49c50769d76375ba2db2bbe5379f58e9116a0bea0e49f35d257b25ea895be39024ce21f54d31923311bc2c7d66ce1eca9a5dbd6",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-0124-20046A30-RF_264-upgradeMe.ota",
@@ -1874,7 +1874,7 @@
     "imageType": 292,
     "manufacturerCode": 4454,
     "sha512": "7d883752d7d3b215a90f1add7bc5b14a2c468dd72bf4936722627339c48d579be505c747e80cebf6669362f25c48423b523ce6fc78ab3a8d157d4b48a4a8332a",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-0128-24031511-upgradeMe-RS 226.zigbee",
@@ -1884,7 +1884,7 @@
     "imageType": 296,
     "manufacturerCode": 4454,
     "sha512": "8d239c44c73d403c15448d5c7e4c15d1b25463bbb4681fdfd184cdb6e5f72b4797d71b746097b14ce0e09b631a9e6a4b4d103caa1175ccd257b9193fe7261120",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-0129-24031511-upgradeMe-RS 227 T.zigbee",
@@ -1894,7 +1894,7 @@
     "imageType": 297,
     "manufacturerCode": 4454,
     "sha512": "c7365c9576886a4fc4ddb6e1256d7dcb75f788ec92631e5cb13b8ae317b876954988632010fbe6604a5d1fd5f25936f61387dd6dda20ca61eb5848999278b964",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012A-24031511-upgradeMe-RB 245.zigbee",
@@ -1904,7 +1904,7 @@
     "imageType": 298,
     "manufacturerCode": 4454,
     "sha512": "a6606afeb0ce56b20d7aa839d40ec079851fa6b39a80a65707d4dbd900fb2ac2582db40b5dc519c473fc51d1e630bb81aded66545283b77f2ac5e91699771cac",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012B-24031511-upgradeMe-RB 249 T.zigbee",
@@ -1914,7 +1914,7 @@
     "imageType": 299,
     "manufacturerCode": 4454,
     "sha512": "d3c86737e3a9de6102c013b00b69ea37c551debb898c25f5ce67bfdab4c52b8acca5932e34953d06087dd078d77d83d5d8654c695af6a18440fc2acea0c07f5f",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012C-24031511-upgradeMe-RB 251 C.zigbee",
@@ -1924,7 +1924,7 @@
     "imageType": 300,
     "manufacturerCode": 4454,
     "sha512": "7be7ca7b54e3f404f164f0ae22386e6180f30a72334909648240a45490002b291e4031a6604d3ed7b894a1105a49f6d088df4a085f434a8b1be512a8552a995d",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012D-24031511-upgradeMe-RB 266.zigbee",
@@ -1934,7 +1934,7 @@
     "imageType": 301,
     "manufacturerCode": 4454,
     "sha512": "317a109be00c0f7b96e7bdb1d60eab57d68149e3a9da78b7fe21db165d22165fef389b8eb4c0463abe27d5e9680a48975a72687900f5baa5e2df5db16eda1348",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012E-24031511-upgradeMe-RB 279 T.zigbee",
@@ -1944,7 +1944,7 @@
     "imageType": 302,
     "manufacturerCode": 4454,
     "sha512": "96c85aab44c85dfaecf0e5728b87de5920aa6d1030e18831cbfd737b5e0772937f55f0e7da1c5356ef6e6756f7c4cffbfc7d0ba095e63d053bde2535a450b72d",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012F-24021511-upgradeMe -RB 286 C.zigbee",
@@ -1954,7 +1954,7 @@
     "imageType": 303,
     "manufacturerCode": 4454,
     "sha512": "3195366686f563306fa7fd9d41656498fb6d15e085d4f691d8464f6de074c1042ed33a6706deea6d9dd001ef535f74cd8dceae1deec38194ab1e3d92a596a11f",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-0130-22151511-upgradeMe  RS 232 C 20230714.ota",
@@ -1964,7 +1964,7 @@
     "imageType": 304,
     "manufacturerCode": 4454,
     "sha512": "cfe7aab8c926345f38aa817a6ac652519cd891eeba8162e680b98dc91e6025ff150a04e618c8abc5528110965d1bf036f324619269d33bb97a535ce766b71a5f",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-0131-24081511-upgradeMe  RB 255 C 20230714.ota",
@@ -1974,7 +1974,7 @@
     "imageType": 305,
     "manufacturerCode": 4454,
     "sha512": "0d1374689790b7d92eecc068303f87ef0d5df1aadddb0a498c9dca73db9313b2239be14b4b63420660da8512a692909cce64b6ff74769fa62bc4fef610c9c366",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-0132-17103685-rb272t-1.7.16.ota",
@@ -1984,7 +1984,7 @@
     "imageType": 306,
     "manufacturerCode": 4454,
     "sha512": "62b9b55d90e15816f611ea1d174a1d1c05e8d854f635ff10ab9e4921e35926992efe7da605f558ed3172c81b91913cb836202a9a3d1649157b2fdcd1566e0261",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0133-17103685-rb247t-1.7.16.ota",
@@ -1994,7 +1994,7 @@
     "imageType": 307,
     "manufacturerCode": 4454,
     "sha512": "4da46054eea1c538f7382ea20ab2df708b64d2ac55c5732fe9e3ef9495a1dbd5f047a066952dd36143860d13ccb325e13c60c342c97faf70c5784608eb5fedc7",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0134-17103685-rf273t-1.7.16.ota",
@@ -2004,7 +2004,7 @@
     "imageType": 308,
     "manufacturerCode": 4454,
     "sha512": "e8978a70c31814c2b720280e1152198416df59d48ce200bcb942c5e1abd14ca55be76d5373df26d77ec28d1eeb4bbc7972fc9c2f420f4941901c7415023a0f31",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0135-17103685-rf274t-1.7.16.ota",
@@ -2014,7 +2014,7 @@
     "imageType": 309,
     "manufacturerCode": 4454,
     "sha512": "ee7f62c9a13949e69e1190088eda29ba0900ee0c6c90b00f90513d55975c8f1ae8b619d2ef4ba566b4e665d9d32a5601395540d9ab39350d3f99959f3e83f4ad",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0136-17103685-rf271t-1.7.16.ota",
@@ -2024,7 +2024,7 @@
     "imageType": 310,
     "manufacturerCode": 4454,
     "sha512": "a337dc7dcef398bda0ef273fde885162862e8e99a8e337c931b77cbc3dc9edb6fd6af3aaa133a756eb30edd525781838c3437c3d7b44dfeb710b2c5b1c154f84",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0209-17103685-bb262-1.7.16.ota",
@@ -2034,7 +2034,7 @@
     "imageType": 521,
     "manufacturerCode": 4454,
     "sha512": "8fcb605c73d677e38f48072562d39d0311deb56bd2ccd87324acefeea405b35e2945df929e8a3c753869acbbee89386258c49c9694adca40a9a3fa6dd7f3f7d2",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0220-20026A30-BF_263-upgradeMe.ota",
@@ -2044,7 +2044,7 @@
     "imageType": 544,
     "manufacturerCode": 4454,
     "sha512": "1fb89b2184d2564e0ecec1adbc2a839fb64bd7ebb0eecc53ea7158c23941546a0946873056c38807b0700c0d2822636576f86404371fff64204a1b06f0d5c010",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-0221-20026A30-BF_265-upgradeMe.ota",
@@ -2054,7 +2054,7 @@
     "imageType": 545,
     "manufacturerCode": 4454,
     "sha512": "29c01a141853afb877ce7ba9df86b0eba2ddb067164d996333c71128fe15d7d3d7dcc4e0bd7662cb7dd440b1705d157aaf30479b75bec445c2b3e7c4a646f9d3",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-022D-24031511-upgradeMe-BY 266.zigbee",
@@ -2064,7 +2064,7 @@
     "imageType": 557,
     "manufacturerCode": 4454,
     "sha512": "e3a75926cd6e19441dac4aec5a6c81aba32c0fc09fb74481cb1140e4284954497167ae2a897346d53b5cd14bb80bb52b6f14bf7356d5de300b1868f62b6ca8e7",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-022F-24021511-upgradeMe BY 286 C.zigbee",
@@ -2074,7 +2074,7 @@
     "imageType": 559,
     "manufacturerCode": 4454,
     "sha512": "a6fdd9ab0f770665e126920143da7c0f66ef5d9fed5f2b76f030c4d21a51ae02d881ca31aa6cb80730246311f8bbaac2f9196b7840ac8bc99a6f22db738e9a00",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-0311-27016A30-SP_222-upgradeMe.ota",
@@ -2084,7 +2084,7 @@
     "imageType": 785,
     "manufacturerCode": 4454,
     "sha512": "cc6096c0d0f29ef27b883b2fe77672e1956fdcf8fbe028e61052f103d68af0d082d61e32dc41a583c9165186924b727e45c3e83e0b17f1077410cbea3d588720",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-0312-27016A30-upgradeMe.zigbee",
@@ -2094,7 +2094,7 @@
     "imageType": 786,
     "manufacturerCode": 4454,
     "sha512": "e04ad772d6e3c263adc8108eb80c811cd1aad5e750241bc77e44067f4b9530098fa31b7b03abec412d9d28e732f9d25ffaf96f7f0ec619e1a18b51cc90b5a35b",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-0313-31016610-upgradeMe.ota",
@@ -2104,7 +2104,7 @@
     "imageType": 787,
     "manufacturerCode": 4454,
     "sha512": "91605b5a7f965ac34a1e72bd2e2adba7abea877182b043b6d21e78ef1aa68005eba7011c548116ef2df74d29c7036e6a2616c65597705fd64d01d2f528ceb986",
-    "otaHeaderString": "GBL Smart Home Plug\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "GBL Smart Home Plug"
   },
   {
     "fileName": "1166-0401-17103685-ae262-1.7.16.ota",
@@ -2114,7 +2114,7 @@
     "imageType": 1025,
     "manufacturerCode": 4454,
     "sha512": "c7bfbb09c6ee55816575099d875b46ad3009329cc651dddf23bb24b8b5b9fdc5a87374f18d54deb9f7ae6e7e012d300969fbd56cf18a8618635b5fc64888a60c",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0402-17103685-ae264-1.7.16.ota",
@@ -2124,7 +2124,7 @@
     "imageType": 1026,
     "manufacturerCode": 4454,
     "sha512": "fdff1b901c31d0e443cab9465cf3d7941e318878079bd25f2dcadd697fd304b7eb6e876f123ad4a55a1da7f4dfb8d5619d87ed00dce36bcfbc7ed050073a1f61",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0414-20026A30-AE_280_C-upgradeMe.ota",
@@ -2134,7 +2134,7 @@
     "imageType": 1044,
     "manufacturerCode": 4454,
     "sha512": "9e80707893222af177ceb158353d1829f5df6b86dab5edda769f62fd60bb4ae8289e63c1d3f139ea4db4a21a6c0779de36767645ee6a51ce6dd9a04d6af81958",
-    "otaHeaderString": "EBL C688_Freelocate\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL C688_Freelocate"
   },
   {
     "fileName": "1166-0430-17103685-ae270t-1.7.16.ota",
@@ -2144,7 +2144,7 @@
     "imageType": 1072,
     "manufacturerCode": 4454,
     "sha512": "a1821008181b2dca54ffb61a99f49fe8c8d8b39fd984d57423e34691de32666d9b2f8bbd3f7f6a929d67229c239b55fcfeb490f352cc0ccc0cb361408bb17b75",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0980-20036A30-RCL_240_T-upgradeMe.ota",
@@ -2164,7 +2164,7 @@
     "imageType": 4660,
     "manufacturerCode": 4655,
     "sha512": "e09e2d301520bf618dd7511ec6df4ac0d659a8a515014d89326610b303df17b992c3ae125ce918debda459c4e783c71546ffe6270c4ae47f89c2673e420c8ab3",
-    "otaHeaderString": "EFR32MG21_Z3\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EFR32MG21_Z3",
     "originalUrl": "https://files.inovelli.com/firmware/DZM32-SN/Beta/1.13/DZM32-SN_1.13.ota"
   },
   {
@@ -2175,7 +2175,7 @@
     "imageType": 257,
     "manufacturerCode": 4655,
     "sha512": "6d480a5d621a16bb3a57fcc1af09071fc528dab2a8f3e479620c3bd75ddfa9e8f624c32b1dc35d5c1bc8db0f67a70ee150ce3a516a2026f717076dcbeba23df7",
-    "otaHeaderString": "EBL VM_SWITCH\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL VM_SWITCH"
   },
   {
     "fileName": "VZM35-SN_1.07.ota",
@@ -2185,7 +2185,7 @@
     "imageType": 513,
     "manufacturerCode": 4655,
     "sha512": "cc2e1639debcebb42e8cb8e48559258378112a94eaf6480721ee9ce5b5ab8d562a2b8c0c6df8819b1db9b3a539178f1b1bbf039243cf1184efe1024e4c8f05d0",
-    "otaHeaderString": "VZM35_MG24\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "VZM35_MG24",
     "originalUrl": "https://files.inovelli.com/firmware/VZM35-SN/Beta/1.07/VZM35-SN_1.07.ota"
   },
   {
@@ -2196,7 +2196,7 @@
     "imageType": 1025,
     "manufacturerCode": 4655,
     "sha512": "daa5570379960cc959d867160bc21d3cf651926af63c4c3076a02810cee1a4b8a4def1a097b2bdaea818c712f39fb93c37ccf84aeb0ada4eaedebd9b1c4eb882",
-    "otaHeaderString": "VMZB_Canopy\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "VMZB_Canopy",
     "originalUrl": "https://github.com/InovelliUSA/Firmware/raw/6608d75c73b5200b20ed197653c9ad3af1f5c1e7/Blue-Series/Zigbee/VZM36-Fan-Plus-Light/Beta/1.01/VZM36_1.01-Beta.ota"
   },
   {
@@ -2207,7 +2207,7 @@
     "imageType": 529,
     "manufacturerCode": 4474,
     "sha512": "ab539a1d694d9488a0deeaa2b0b809bc19b88ba7323eecba7f8abff7e989cee43112b29eb39a8548c0da480d258d7be0f681adb5b848bece0b2a55692c3b2b95",
-    "otaHeaderString": "EBL Zigbee_System'\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL Zigbee_System'"
   },
   {
     "fileName": "ZLL_HS_4f_GJ_Release_10.03.32.02.zigbee",
@@ -2387,7 +2387,7 @@
     "imageType": 61441,
     "manufacturerCode": 61731,
     "sha512": "53efac6c622306df81fd6d36d52eca301df138aedfc1bf3366a5d77b685cf2c3e20016eff83d1cf62ab8257dfefa91af05e6086429c6b56517e342d07d0a27b8",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://fw.jethome.ru/media/firmwares/jethome/zigbee/release/15/jethome_zigbee_release_15_zigbee.ota.zigbee",
     "manufacturerName": [
       "JetHome"
@@ -2402,7 +2402,7 @@
     "imageType": 124,
     "manufacturerCode": 4489,
     "sha512": "e501377b05e04dc72f2b220ce19002f4a3b34a3f132b9dcc047e2b498e8c70999d93e7d7e5703b42fbb787876bb89ebde43dd8dc50bb64d201000a3f9294447a",
-    "otaHeaderString": "EBL AcSensor_Y\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL AcSensor_Y",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=124&version=17.67.102.48",
     "releaseNotes": "1. Fix bug that sensor freeze after long time running in big system.\r\n2. Fix bug that sensor automatic left network occasionally."
   },
@@ -2414,7 +2414,7 @@
     "imageType": 151,
     "manufacturerCode": 4489,
     "sha512": "e477bea2476d14f8ea6c639fec2a90f01d631dab3e0184ecfe11cfb5f0453a1cd0348eee3a72950d33ca370df573c8f71716cdcde97ffe272272158a4c1a2fe6",
-    "otaHeaderString": "EBL AcSensor_Y\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL AcSensor_Y",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=151&version=17.67.102.48",
     "releaseNotes": "1. Fix bug that sensor freezing after long time running.\r\n2. Fix bug that sensor automatic leave network occasionally.\r\n3. Fix manual reset fail if press more than 15 seconds."
   },
@@ -2426,7 +2426,7 @@
     "imageType": 25,
     "manufacturerCode": 4489,
     "sha512": "1a269383342ad612e3a30eafdb2363a4d2feda40718bae10a6eeb0970d2771df670287b9741e37cce14db1d40a39b5bb334226836171565cb9cf23d5349cd04d",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "A19_TW_10_year_IMG000D_00102428-encrypted.ota",
@@ -2436,7 +2436,7 @@
     "imageType": 13,
     "manufacturerCode": 4489,
     "sha512": "60a0a7447a209707257775697c16150844641442c4e192b89fe1858c50e3df54f77a8102d113de8cd75b3c3ea64eeeb68211d5affdb9e605cf830c119dcf4415",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "A19_W_10_year_IMG000C_00102428-encrypted.ota",
@@ -2446,7 +2446,7 @@
     "imageType": 12,
     "manufacturerCode": 4489,
     "sha512": "4efd3c4d802dc32489b1de0aca342bf6e7c55f2ce488987889707d7a513538f6901e39f0fdfdd461622ecaa8c2322237aaf73a5a50523b55f60b4efdb49fc70b",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "A60S_RGBW-0x1189-0x00A0-0x03197310-MF_DIS-20240523095111-3221010102432.ota",
@@ -2456,7 +2456,7 @@
     "imageType": 160,
     "manufacturerCode": 4489,
     "sha512": "d0ccca81ba3598d79b70ab4ee836c230d725cf02e5ee4b6feff7d4301c3c86afbe2b30504e96cee88b5333aec580d2c1e1b09cfbc4d4e359f744b86deb6f26cc",
-    "otaHeaderString": "A60S_RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "A60S_RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=160&version=3.25.115.16",
     "releaseNotes": "(1) Security patch\r\n(2) Refine RGBW color control.\r\n(3) Support sleep mode in Hue automation settings. "
   },
@@ -2468,7 +2468,7 @@
     "imageType": 162,
     "manufacturerCode": 4489,
     "sha512": "ed88b8e69fbae0d071962bd9d65b0d54353c20f8824e5a07ddc5a3dcc586ad8aea8a809e97aff6d49bc41140c5a0bbac7e3519b19562bdb98d5ecfc01225c703",
-    "otaHeaderString": "A60S_TW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "A60S_TW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=162&version=3.23.115.16",
     "releaseNotes": "(1) Add security patch. "
   },
@@ -2480,7 +2480,7 @@
     "imageType": 61,
     "manufacturerCode": 4489,
     "sha512": "393017c8b6fe46366e9cbfdec965caf1abaa9db310d6cbcd61017f5341000066e38cf848f7fa6ddb0d259542299a008a955dc22381702925b5cd989715339173",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=61&version=1.5.100.0",
     "releaseNotes": "Support ZLO"
   },
@@ -2492,7 +2492,7 @@
     "imageType": 138,
     "manufacturerCode": 4489,
     "sha512": "c1506be6d427dff52ef7cc3d1d877fcab87d413f22866af878b3e0e801a8ba7bf863061052387091bb14a126dff04d6dc2897b38be2598c20056fc56b580aee0",
-    "otaHeaderString": "A60_RGBW_Value_II\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "A60_RGBW_Value_II",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=138&version=3.25.115.16",
     "releaseNotes": "(1) Security patch\r\n(2) Refine RGBW color control.\r\n(3) Support sleep mode in Hue automation settings. "
   },
@@ -2504,7 +2504,7 @@
     "imageType": 139,
     "manufacturerCode": 4489,
     "sha512": "8366767213db679d702c51e9130554afcd55730ff8a1203d08d4d43729b2f9905f061f6a89b51bfce7d8da85bc5102ee38948680c002861822683cc451ed4211",
-    "otaHeaderString": "A60_TW_Value_II\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "A60_TW_Value_II",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=139&version=3.23.115.16",
     "releaseNotes": "(1) Add security patch. "
   },
@@ -2516,7 +2516,7 @@
     "imageType": 60,
     "manufacturerCode": 4489,
     "sha512": "6f9a19ff9388d9db2ed7b769db40f156c425fc46a1b67b24ec2eb47ae40b21e2a9b4cc7cc717f24847e134d28c88a545909cd18aad012058eef3bfca7fec3981",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=60&version=1.5.100.0",
     "releaseNotes": "Support ZLO"
   },
@@ -2528,7 +2528,7 @@
     "imageType": 163,
     "manufacturerCode": 4489,
     "sha512": "1600634bb26a61cb275d022c3a234f4ce62a77b75ac38b36bba8c45363ccfe639c0e77890473133acb3448c7ed70387c3945967d411af5f58b21c513f915e8c0",
-    "otaHeaderString": "B40S_TW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "B40S_TW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=163&version=3.23.115.16",
     "releaseNotes": "(1) Add security patch. "
   },
@@ -2540,7 +2540,7 @@
     "imageType": 52,
     "manufacturerCode": 4489,
     "sha512": "b2b40193c7536afef6cc1364a075d2546c1f812ae395addf37b96c4532ee2d1e43cd871ce254a1f16c499f77717e96e2d7bc07ef72c3d71d3a7451031c822b36",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=52&version=1.5.100.0",
     "releaseNotes": "Support ZLO"
   },
@@ -2552,7 +2552,7 @@
     "imageType": 140,
     "manufacturerCode": 4489,
     "sha512": "e7d3fad4b806240d3a8016dd69b356038549f20130e154a5ed763e2e6b4c0954833d9f452c1bb9b37b0ae0fa5a5c616cb83563e57f628ee2b62c1449378888ae",
-    "otaHeaderString": "B40_TW_Value\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "B40_TW_Value",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=140&version=3.23.115.16",
     "releaseNotes": "(1) Add security patch. "
   },
@@ -2564,7 +2564,7 @@
     "imageType": 51,
     "manufacturerCode": 4489,
     "sha512": "8bcea29b2c059391bbfcd0b9998db6c2328ee1cc988226049462d164373cc0b2a84178e0ae4a9331d022b35cf8f2bf93d800ece0bbabbf0554298fa69a665256",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=51&version=1.5.100.0",
     "releaseNotes": "Support ZLO"
   },
@@ -2576,7 +2576,7 @@
     "imageType": 27,
     "manufacturerCode": 4489,
     "sha512": "68bfb341e4a3327bfe6c3ac2a469bf9c8497298ef4ea05a956058bc306bf33e1fd664068521d9f99704eeb95f1a1c6ade63a03f142cc4f4ee45c6a30220da247",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "BR30_TW_IMG001A_00102428-encrypted.ota",
@@ -2586,7 +2586,7 @@
     "imageType": 26,
     "manufacturerCode": 4489,
     "sha512": "8fffbd0b82ecdabdd76890c8def88c431116a9daf7c0fa6cc7bbab14dc893be235fbc092375e70fe0679a1a710aba246bdf7f47536242256148a6a11987f8d70",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "BR30_W_10_year_IMG000F_00102428-encrypted.ota",
@@ -2596,7 +2596,7 @@
     "imageType": 15,
     "manufacturerCode": 4489,
     "sha512": "928f699ccb59d763a442e0d00ec842c5c95b59c0354d2b447b172f98ef9410a90e8315a460c122d3ba4f8e502fe8a6ec8e40b44c798855a995ff536b405232f4",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "CLA60_RGBW_Z3_IM0011_01066400-encrypted_202126110358_withoutMF.ota",
@@ -2606,7 +2606,7 @@
     "imageType": 17,
     "manufacturerCode": 4489,
     "sha512": "e6667216432104472db651baec065ecb2cd6a7e00efa5ea56ca57ad0c5b8e3c67ad07feb8fced88dde2c4fbdcd4b90cdc41343ca9edbf69df37b35395596dbf0",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=17&version=1.6.100.0",
     "releaseNotes": "1. Rollback Protection enabled \r\n2. Fade off feature removed\r\n3. ZLO commands support\r\n4. Color Improvement "
   },
@@ -2618,7 +2618,7 @@
     "imageType": 33,
     "manufacturerCode": 4489,
     "sha512": "4857e26de657a952f7878edfb03b58020e3b64715bfd3c00d7f0f78bb9c8e8f3002ae2d10bd3c8cbc2e071b7909ae27436cdfe82fb3c4b3f360963a49e5b3806",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "DIM-A60_DIM_T-0x00CD-0x03203660.OTA",
@@ -2628,7 +2628,7 @@
     "imageType": 205,
     "manufacturerCode": 4489,
     "sha512": "a7be48d6c9e1473748af00bf8696ead99497c7dc5006f76a888ca6e386ed0d266047ff08c4303b85b1f56ea4edaca4f03a0c2aab3842a24707c2fd4fcd73ec8a",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=205&version=3.32.54.96",
     "releaseNotes": "1. Support maximum 30 groups\r\n2. Enable the watchdog\r\n3. Set the Tx power to 9.8dB\r\n4. For Filament dimmable bulbs only, set the minimum level to 3%(according to APP) = the minimum PWM duty cycle is 15/255"
   },
@@ -2640,7 +2640,7 @@
     "imageType": 208,
     "manufacturerCode": 4489,
     "sha512": "3854e452e13ff0c973531e99a842d36fcbff6a4d43f2edd57a472bde48b32eb590759fcaf96ff0824845e1b9c63666adc21d4070c367ff3b18505ff7cab0d5f3",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=208&version=3.32.54.96",
     "releaseNotes": "1. Support maximum 30 groups\r\n2. Enable the watchdog\r\n3. Set the Tx power to 9.8dB\r\n4. For Filament dimmable bulbs only, set the minimum level to 3%(according to APP) = the minimum PWM duty cycle is 15/255"
   },
@@ -2652,7 +2652,7 @@
     "imageType": 184,
     "manufacturerCode": 4489,
     "sha512": "d50a9ebeb0a3d3eefabaf593b71aa229213b44d90046220e753be73e5c72a51c7fb419db27fb667bc1a949f6c9a159edf68ce5bf24f49c7056a668c6d0ee0504",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=184&version=3.32.54.96",
     "releaseNotes": "1. Support maximum 30 groups\r\n2. Enable the watchdog\r\n3. Set the Tx power to 9.8dB\r\n4. For Filament dimmable bulbs only, set the minimum level to 3%(according to APP) = the minimum PWM duty cycle is 15/255"
   },
@@ -2664,7 +2664,7 @@
     "imageType": 209,
     "manufacturerCode": 4489,
     "sha512": "92741c25cf6da726cf1d83d45b3d8420546a52c3db0b6c8237551e8d71b8badb6bd3023348d58b94118eebb454cafc06e7a778c3899555b9af5f3e4cef81ae37",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=209&version=3.32.54.96",
     "releaseNotes": "1. Support maximum 30 groups\r\n2. Enable the watchdog\r\n3. Set the Tx power to 9.8dB\r\n4. For Filament dimmable bulbs only, set the minimum level to 3%(according to APP) = the minimum PWM duty cycle is 15/255"
   },
@@ -2676,7 +2676,7 @@
     "imageType": 210,
     "manufacturerCode": 4489,
     "sha512": "e686f9d515678dcf10bba87545f2588c39354635c2b5e95ac060b5447600819c733c436ce16dcf6122c35d4b24cb4d7a4288c8fc9e71985f88d23ee111bb23ed",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=210&version=3.32.54.96",
     "releaseNotes": "1. Support maximum 30 groups\r\n2. Enable the watchdog\r\n3. Set the Tx power to 9.8dB\r\n4. For Filament dimmable bulbs only, set the minimum level to 3%(according to APP) = the minimum PWM duty cycle is 15/255"
   },
@@ -2688,7 +2688,7 @@
     "imageType": 206,
     "manufacturerCode": 4489,
     "sha512": "b3867cfd8f681ae951ac614b822ad4c0368d4eb5fcf4055d643fb1abf07aebdc763e32f5bc06aa3d491202b4db2621db4bd9810189d2af8bb1c6d85e4c5ac3dd",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=206&version=3.32.54.96",
     "releaseNotes": "1. Support maximum 30 groups\r\n2. Enable the watchdog\r\n3. Set the Tx power to 9.8dB\r\n4. For Filament dimmable bulbs only, set the minimum level to 3%(according to APP) = the minimum PWM duty cycle is 15/255"
   },
@@ -2700,7 +2700,7 @@
     "imageType": 207,
     "manufacturerCode": 4489,
     "sha512": "2085b60c00c66103d3d178822f210df1f1243c445f2dcd582d854ba244a7ac5993f88f1621fd33eade6282c9df9411304ce8cf6301689309d88e7a95128e573e",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=207&version=3.32.54.96",
     "releaseNotes": "1. Support maximum 30 groups\r\n2. Enable the watchdog\r\n3. Set the Tx power to 9.8dB\r\n4. For Filament dimmable bulbs only, set the minimum level to 3%(according to APP) = the minimum PWM duty cycle is 15/255"
   },
@@ -2712,7 +2712,7 @@
     "imageType": 222,
     "manufacturerCode": 4489,
     "sha512": "393c6424ec18ebb05b0c1d4aa9b8c7ebffcf2eb27201dd9e66462623456af1b95ddc70436bfb9d5b19ff9665cecab3a419cbf543f38008cbd6c0d2da541facff",
-    "otaHeaderString": "TUBE_T8_CON_1200_16W_830ZBVR\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "TUBE_T8_CON_1200_16W_830ZBVR",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=222&version=2.5.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -2724,7 +2724,7 @@
     "imageType": 199,
     "manufacturerCode": 4489,
     "sha512": "a5fe0c1a70dbf225591ba8cfde1dbdd49d8997e5e0a850a9f06d83781a45247572e4ace263e93e3381843c2f42076f6a0266b040aff2ee9e7bd513d31592cb19",
-    "otaHeaderString": "TUBE_T8_CON_1200_16W_840ZBVR\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "TUBE_T8_CON_1200_16W_840ZBVR",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=199&version=2.5.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -2736,7 +2736,7 @@
     "imageType": 200,
     "manufacturerCode": 4489,
     "sha512": "f31f82039d767be2f7b85eb9d0f7dd9c2573a1558b6745eb588a8191ff0edd6d7ba36400ecee5697845c28910360635521922667ccd49ced2ab7fa37d55612f6",
-    "otaHeaderString": "TUBE_T8_CON_1200_16W_865ZBVR\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "TUBE_T8_CON_1200_16W_865ZBVR",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=200&version=2.5.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -2748,7 +2748,7 @@
     "imageType": 221,
     "manufacturerCode": 4489,
     "sha512": "b69c54bc99b7ecf1b1a13ac41ef52963f0ab41e8fdf0f2b032aa28fbbe1ab069caf3ec235f5619767a8478f5858f831961ddaa2cf8ce8edc9704acb08d132cd1",
-    "otaHeaderString": "TUBE_T8_CON_1500_24W_830ZBVR\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "TUBE_T8_CON_1500_24W_830ZBVR",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=221&version=2.5.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -2760,7 +2760,7 @@
     "imageType": 201,
     "manufacturerCode": 4489,
     "sha512": "f23ea8d9035ae309dbe1b444316ea8a19436c5f0c2f100e8ea7399e4d31a6c4eee5751b8d65bf09eaeb5321cc2963075b4e4c89204cf4b2350926c59d3eb9bfd",
-    "otaHeaderString": "TUBE_T8_CON_1500_24W_840ZBVR\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "TUBE_T8_CON_1500_24W_840ZBVR",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=201&version=2.5.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -2772,7 +2772,7 @@
     "imageType": 202,
     "manufacturerCode": 4489,
     "sha512": "2dfb53a2e8f3db70d12485bcf0c563251c3593bff503b677e5b3988092a28ed782558d0976237da3145d5998c005ce55cf43e60ebc54701cbb1c6139b221a290",
-    "otaHeaderString": "TUBE_T8_CON_1500_24W_865ZBVR\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "TUBE_T8_CON_1500_24W_865ZBVR",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=202&version=2.5.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -2784,7 +2784,7 @@
     "imageType": 223,
     "manufacturerCode": 4489,
     "sha512": "6510d671f8a216cbb08ecfea2033318fcc8e5c55c3290c576c614e7f98f948b9a40d2cc5c720bc0b3d754a087ba3cc053a6780f5fc8af6317145177df0ee1cba",
-    "otaHeaderString": "TUBE_T8_CON_600_7_5W_830ZBVR\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "TUBE_T8_CON_600_7_5W_830ZBVR",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=223&version=2.5.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -2796,7 +2796,7 @@
     "imageType": 203,
     "manufacturerCode": 4489,
     "sha512": "10cccaed0ea69674eeffa6df77eea4873be3d9e8c29fa21a6c1ff1d45305e74741942f47ea23aad6a1f3385fdf4b482e681265ae82bbde4c6acb52f4ad75530c",
-    "otaHeaderString": "TUBE_T8_CON_600_7_5W_840ZBVR\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "TUBE_T8_CON_600_7_5W_840ZBVR",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=203&version=2.5.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -2808,7 +2808,7 @@
     "imageType": 204,
     "manufacturerCode": 4489,
     "sha512": "678cb88d600622f7c62c55c5728c6dd2dcb384210550dd88dcd71355425197ca2ff76c6f541b6f7aba474cd029ee8a06a75236f6174deed229678742b33dede0",
-    "otaHeaderString": "TUBE_T8_CON_600_7_5W_865ZBVR\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "TUBE_T8_CON_600_7_5W_865ZBVR",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=204&version=2.5.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -2820,7 +2820,7 @@
     "imageType": 135,
     "manufacturerCode": 4489,
     "sha512": "b4c7cb37a7cee34df7d6935222cbf56f8a25b5a5ff5831bd4a906336b4fa9cfab30d8d5841d642c3ac6fe47067773173921119ace67cf9326e98de20b74d0eae",
-    "otaHeaderString": "DL_PFM155UGR_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "DL_PFM155UGR_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=135&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2832,7 +2832,7 @@
     "imageType": 136,
     "manufacturerCode": 4489,
     "sha512": "df38535a415e0db5e7eafb32c81b6ee04068cdcdf78d658073649197661b157335f0dc7cec4e26369a99ed688461db045aa4ea8e48c8007b2e2fc337734b353b",
-    "otaHeaderString": "DL_PFM195UGR_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "DL_PFM195UGR_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=136&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2844,7 +2844,7 @@
     "imageType": 132,
     "manufacturerCode": 4489,
     "sha512": "c240d8f145914f61aaf701d1a772f7cc72a1a778df368261cf6175ae685f1354f4ab86df50d682547f0e54a80db02efbf6ddaa39583086800563a7c585ee67f3",
-    "otaHeaderString": "LN_Indivi1200_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "LN_Indivi1200_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=132&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2856,7 +2856,7 @@
     "imageType": 133,
     "manufacturerCode": 4489,
     "sha512": "d84bc210d6a8a1f0e7f625d68ae9f9d6d69f37248084e025ba520bd9192090b2f6e9f20233e16478dfa9e8316631e490dda02fa7aabfa184033a75bbf69ff49e",
-    "otaHeaderString": "LN_Indivi1500_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "LN_Indivi1500_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=133&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2868,7 +2868,7 @@
     "imageType": 134,
     "manufacturerCode": 4489,
     "sha512": "ce82c7e358c5a5b23112939da57d220f94f58f4ca5a644827c9dc35ae1c31b6c563e3e914bdcbdb80b84a51c0a2cb21d19d22aae9c82b6cca0693e0aaf6a444e",
-    "otaHeaderString": "PL_DI1200_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_DI1200_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=134&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2880,7 +2880,7 @@
     "imageType": 130,
     "manufacturerCode": 4489,
     "sha512": "5412293f3bb6338d8423aa7e6e33760da3b465dc4e6459305f819c7388fd983ff51103f8bc5ad48d63941eaa3b581a278eefd88bf7c32fbaa8bc9275a54703a4",
-    "otaHeaderString": "PL_Indivi600_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_Indivi600_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=130&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2892,7 +2892,7 @@
     "imageType": 131,
     "manufacturerCode": 4489,
     "sha512": "b6d8215e1fe268f953bc5989f46d4d7ff894b661f7bdf5103e7d015fe35b77987b37c57869b5a9cc2865bdc0b616be5466d0a667be322cb0518321fdf4056d63",
-    "otaHeaderString": "PL_Indivi625_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_Indivi625_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=131&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2904,7 +2904,7 @@
     "imageType": 128,
     "manufacturerCode": 4489,
     "sha512": "678c6940cc738d658658c2bd759b3e831c55c28a9cb121f4dcd2ab6c99e388e0d341af886cb5ab5c58d77847d72f6c2d1c34c10cdcedebcf29532045e955fdc8",
-    "otaHeaderString": "PL_PFM600UGR_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_PFM600UGR_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=128&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2916,7 +2916,7 @@
     "imageType": 137,
     "manufacturerCode": 4489,
     "sha512": "31f8d55de2ed328c6c00195499c0cecd8ec8eeb86a147deac7b7f92719600e7fe1390fd78dd03d5bb5e5e1521dec63bba760eea757662a6d50f5b813fcc2df64",
-    "otaHeaderString": "PL_PFM600_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_PFM600_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=137&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2928,7 +2928,7 @@
     "imageType": 129,
     "manufacturerCode": 4489,
     "sha512": "f568beab5a4f3266d22a658ea9bdd877f7192004560252682ad4e74ad56e27b4a59bbb8869f615aa8e80c6b21f7cb9e6f52123a8729886bb7e1de188ac924aa6",
-    "otaHeaderString": "PL_PFM625UGR_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_PFM625UGR_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=129&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2940,7 +2940,7 @@
     "imageType": 127,
     "manufacturerCode": 4489,
     "sha512": "7573438156a9b63831d2a804d00e83c551b510337a664a261e63baef996d91c9f6a7c47206a23a8f7f962d1a375ce43ac489f1e4c4419f0b09ff7ca8e6e43224",
-    "otaHeaderString": "PL_PFM625_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_PFM625_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=127&version=2.17.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix abnormal device announcement."
   },
@@ -2952,7 +2952,7 @@
     "imageType": 150,
     "manufacturerCode": 4489,
     "sha512": "bcabc6ddc1c94263acab14bb699b01082dd013d2617269fdb8ca3f0e192fd2f9f0a854dec96917d8684259598c26276238073f0daf4ea008eae4db5e991e68b7",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=150&version=1.10.100.0",
     "releaseNotes": "1. Fix bug that Biolux Gen I luminaire lost HCL mode occasionally."
   },
@@ -2964,7 +2964,7 @@
     "imageType": 101,
     "manufacturerCode": 4489,
     "sha512": "0e9ad28f4e950d73417489ec5f046d72c93f71d327eb23123d16941a5e6b42e0ca8b0c75cf56a443ab2d0d7d6d23433bfed4533dde65ccb07c177802872ddb0c",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "Edge_Lit_Under_Cabinet_IMG0023_00102411-encrypted.ota",
@@ -2974,7 +2974,7 @@
     "imageType": 35,
     "manufacturerCode": 4489,
     "sha512": "4b657dd79631031aac8fd8baa1dd7ad1f1c7d1ba34aa40849bd4fb543ea0917dfee11c579aaa31f2c5eb8bdaa725b2140dd68c021cb7252492f79cf0040e4fa4",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "FLEX_Outdoor_RGBW_IMG001F_00102428-encrypted.ota",
@@ -2984,7 +2984,7 @@
     "imageType": 31,
     "manufacturerCode": 4489,
     "sha512": "6bb62d30849317b975d5f614a5a9f9a7d8e2b82519584b1b9ef69555b77646f9082dcde22c6212ed8cc184b35dee64e31d486a739b023efe81a9624dde69b89a",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "FLEX_RGBW_IMG001E_00102428-encrypted.ota",
@@ -2994,7 +2994,7 @@
     "imageType": 30,
     "manufacturerCode": 4489,
     "sha512": "4e49ac2d15af8e28157db8d70f782d1a2e2eb783f0a11a0a2da623d2c8d5b29dd5165971de241fa1c2b21d9bebb2b13289336203cc2d509705937c31b9838648",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "Flex_RGBW_Z3_IM002A_01066400-encrypted_202216020348_withoutMF.ota",
@@ -3004,7 +3004,7 @@
     "imageType": 42,
     "manufacturerCode": 4489,
     "sha512": "511af78337e0e0a68140c062733b852fe03c9ff67f15e4a93dccb9ee64eb37bad8f184e3edfb4ac4d587ff8abb6a00c24121993f8a20d6a365b7218423acaaf0",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=42&version=1.6.100.0",
     "releaseNotes": "1. Rollback Protection enabled \r\n2. Fade off feature removed\r\n3. ZLO commands support\r\n4. Color Improvement "
   },
@@ -3016,7 +3016,7 @@
     "imageType": 34,
     "manufacturerCode": 4489,
     "sha512": "e73eeb57bb577cb3a365583d3e0cb44524941f25ac5f69e7bb68f707a68fb397e075598b79edaea2267cf488ba731ea13731833508c5d3ed60c00e8d7d4dab84",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "Gardenpole_Mini_RGBW_Z3_IM0040_01066400-encrypted_202210011005_withoutMF.ota",
@@ -3026,7 +3026,7 @@
     "imageType": 64,
     "manufacturerCode": 4489,
     "sha512": "7a34a152205947dc93ae9748099140f20fb87dbc47c6fea09ddc8bb8cf53b594aa47dc7f7e3fac92f7db9b8ed8eeaaad7adc03f47b90501959fb76e72652d940",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=64&version=1.6.100.0",
     "releaseNotes": "1. Rollback Protection enabled \r\n2. Fade off feature removed\r\n3. ZLO commands support\r\n4. Color Improvement "
   },
@@ -3038,7 +3038,7 @@
     "imageType": 59,
     "manufacturerCode": 4489,
     "sha512": "130bf1100ebe5d9225a110e8446e9555929380358ee9a7d726a00562b46c0a9ce50b66f94fb1cfb9d6fdf82547c0773512d6f5d78a070a46183b07ddcd3d0cc6",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=59&version=1.6.100.0",
     "releaseNotes": "1. Rollback Protection enabled \r\n2. Fade off feature removed\r\n3. ZLO commands support\r\n4. Color Improvement "
   },
@@ -3050,7 +3050,7 @@
     "imageType": 111,
     "manufacturerCode": 4489,
     "sha512": "f4cb4724cca17e70883068bd886fa785be6c2e091270663712a97c019446eccd21c25a821cf0035d55a39cc2efdaac16419da47945e4be5faaa1bcf483892c09",
-    "otaHeaderString": "LEDVANCE_DIM\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "LEDVANCE_DIM",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=111&version=3.23.115.16",
     "releaseNotes": "(1) Add security patch. "
   },
@@ -3062,7 +3062,7 @@
     "imageType": 32,
     "manufacturerCode": 4489,
     "sha512": "a3284885687a2424b61d05285e3021e91ad5627bfe50566eaabb5b2bf55444c0d1064b66292d7679f6a3f320281c4dfb7262d2466492d4b54dcd7237dbf5aebf",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "Outdoor_FLEX_RGBW_Z3_IM005C_01066400-encrypted_202210011002_withoutMF.ota",
@@ -3072,7 +3072,7 @@
     "imageType": 92,
     "manufacturerCode": 4489,
     "sha512": "0f6b59d25e4ca7047c898b9b74358f4efbf89ae37f7b8f706dccac741d36023a71624addac0ed7e4a60da8c96995395a10dea15cbafaa8030130261a1f9f5110",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=92&version=1.6.100.0",
     "releaseNotes": "1. Rollback Protection enabled \r\n2. Fade off feature removed\r\n3. ZLO commands support\r\n4. Color Improvement "
   },
@@ -3084,7 +3084,7 @@
     "imageType": 164,
     "manufacturerCode": 4489,
     "sha512": "b6cda1628d320f1644420100c79c5a1888ae4257a53f4dc490f18e83a3f69120b33944b4faa3613f80a3c9ebff3749e9fa74af1506c04254b8d11d4e1801ccb4",
-    "otaHeaderString": "P40S_TW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "P40S_TW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=164&version=3.23.115.16",
     "releaseNotes": "(1) Add security patch. "
   },
@@ -3096,7 +3096,7 @@
     "imageType": 141,
     "manufacturerCode": 4489,
     "sha512": "840e07b58c0ca4df0285e8d49ef192ce05d005ed189e619bd3342a4579ab9f464ead3ae0bd941e9ed29c2df05e68e520de7d2f07102753ea634089dbe9459ab0",
-    "otaHeaderString": "P40_TW_Value\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "P40_TW_Value",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=141&version=3.23.115.16",
     "releaseNotes": "(1) Add security patch. "
   },
@@ -3108,7 +3108,7 @@
     "imageType": 166,
     "manufacturerCode": 4489,
     "sha512": "fb4132facbb0d4c2db44a5f1a55a062516fd95bfd157ae8184710b785f488655174eca264a47da8dc2d05f145d80beee4b07adfc40e41546fa3ed73fd88be7ef",
-    "otaHeaderString": "PAR16S_RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PAR16S_RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=166&version=3.25.115.16",
     "releaseNotes": "(1) Security patch\r\n(2) Refine RGBW color control.\r\n(3) Support sleep mode in Hue automation settings. "
   },
@@ -3120,7 +3120,7 @@
     "imageType": 165,
     "manufacturerCode": 4489,
     "sha512": "bbd0f303f2f47b5a4c99e13188860e18a7b2a21ea808b035356182bf3e6d42306a34312c8126d9c6f505884332a1b72bfac6a4049e41da04b843992d09ab0839",
-    "otaHeaderString": "PAR16S_TW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PAR16S_TW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=165&version=3.23.115.16",
     "releaseNotes": "(1) Add security patch. "
   },
@@ -3132,7 +3132,7 @@
     "imageType": 49,
     "manufacturerCode": 4489,
     "sha512": "9ead17873dd80c19bd7c5ed9647f15a02f66d314a9ead8f142f93e1bc32139badc403e33fa0a2fd4d74d35defd0ed1df41eebba7abed88e1519e9d4e88f97927",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "PAR16_RGBW_Value-0x1189-0x008E-0x03197310-MF_DIS-20240523094504-3221010102432.ota",
@@ -3142,7 +3142,7 @@
     "imageType": 142,
     "manufacturerCode": 4489,
     "sha512": "805309879e74f225530aebe850d4f86a43b48273dfe24046addbb263b8f580b69d44e9b2c712098e6c8386e7865122cb14564b0e17d0ce1c24397384bf4d0031",
-    "otaHeaderString": "PAR16_RGBW_Value\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PAR16_RGBW_Value",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=142&version=3.25.115.16",
     "releaseNotes": "(1) Security patch\r\n(2) Refine RGBW color control.\r\n(3) Support sleep mode in Hue automation settings. "
   },
@@ -3154,7 +3154,7 @@
     "imageType": 48,
     "manufacturerCode": 4489,
     "sha512": "46ecf61b702216a68504b404ec6bcadb69a79aa42658a440cad157cf023d5d01e7d3cc36f2d095e9b9b2eef93a0d1a1e5827f1ebebb0b8353af6a3defba30bdd",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=48&version=1.6.100.0",
     "releaseNotes": "1. Rollback Protection enabled \r\n2. Fade off feature removed\r\n3. ZLO commands support\r\n4. Color Improvement "
   },
@@ -3166,7 +3166,7 @@
     "imageType": 143,
     "manufacturerCode": 4489,
     "sha512": "8e68bc40a53736aac839cb57b6b4424b893a826e8a4f755dc9286b16ce06b1fea9307938ca5f4e68695ea3c43b76b6e0c34479b269f0c80e19b1379be5c2d5b1",
-    "otaHeaderString": "PAR16_TW_Value\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PAR16_TW_Value",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=143&version=3.23.115.16",
     "releaseNotes": "(1) Add security patch. "
   },
@@ -3178,7 +3178,7 @@
     "imageType": 46,
     "manufacturerCode": 4489,
     "sha512": "d330be4e977f4ebfc5cbf6357c0eb0d36c957b5972d2e45c1b2ed74960d09df4bd65f9d745161e84dae65ecf24a911d0c3a17a1113e82ab0ae2fe831d6f70ae1",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=46&version=1.5.100.0",
     "releaseNotes": "Support ZLO"
   },
@@ -3190,7 +3190,7 @@
     "imageType": 16,
     "manufacturerCode": 4489,
     "sha512": "584fef08d2cc42006e14f9c3b632c6536355932beab0d8166fd7a32096ad3d7cd515c946e48195c356b175f08653bc80a589ce656dd1c98ce888043edbc4a95d",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "PLUG_COMPACT_EU_T-0x00D6-0x032B3674-MF_DIS.OTA",
@@ -3200,7 +3200,7 @@
     "imageType": 214,
     "manufacturerCode": 4489,
     "sha512": "bc45a149b84113718eee4a127fc0bcb4c25c905efa805140de278adc7730461717b256bebe2befdce7e777078e498aae4369e48e9f899526630c4f5a658d933c",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=214&version=3.43.54.116",
     "releaseNotes": "1. Add the \"startuponoff\" attribute.\r\n2. After a successful OTA, the socket maintains its previous state."
   },
@@ -3212,7 +3212,7 @@
     "imageType": 212,
     "manufacturerCode": 4489,
     "sha512": "de0dbabc38386eef03c3a49330a72e21be11cc16f1254da44c5b2d1d828e18150d3ae80bb05a357ae4f1f7188d621dac4f1263244eeab944ffd271d8dc158c96",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=212&version=3.43.54.116",
     "releaseNotes": "1. Add the \"startuponoff\" attribute.\r\n2. After a successful OTA, the socket maintains its previous state."
   },
@@ -3224,7 +3224,7 @@
     "imageType": 194,
     "manufacturerCode": 4489,
     "sha512": "249ec36e24e3a8858093d04967bee25eb350870993fa033a2e04a123242aa52d1f276526fb893abd39e4a85409f5d364e5c3ad0bbb555479604ee4edf4bf0843",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=194&version=3.43.54.116",
     "releaseNotes": "1. Add the \"startuponoff\" attribute.\r\n2. After a successful OTA, the socket maintains its previous state."
   },
@@ -3236,7 +3236,7 @@
     "imageType": 213,
     "manufacturerCode": 4489,
     "sha512": "db2ed859306e90874012e305e984dedd5d437410ae920c71d0dfb6814ce74c65c41ade1d6c63892c91c6ae6d648ac5be253c35344bbec270d08b462eb940e6cb",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=213&version=3.43.54.116",
     "releaseNotes": "1. Add the \"startuponoff\" attribute.\r\n2. After a successful OTA, the socket maintains its previous state."
   },
@@ -3248,7 +3248,7 @@
     "imageType": 149,
     "manufacturerCode": 4489,
     "sha512": "7b56e97da0f534b598d03c753d19ce041f1a0831b5a61b6f004485923d542c6048bfaf612f4c4e025f22aec9a790b7c94098b4bdd783b0c8d2c79f171037f05e",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=149&version=1.10.100.0",
     "releaseNotes": "1. Fix bug that Biolux Gen I luminaire lost HCL mode occasionally."
   },
@@ -3260,7 +3260,7 @@
     "imageType": 148,
     "manufacturerCode": 4489,
     "sha512": "600b8867605e9cfb1f6aa6e5907617d687e68d333ef27fe2cb7c970297f9e95041d601f65dca315f3a90c30cd62d7f0ab12dff78a297c8a66ba4f56f935a3ac6",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=148&version=1.10.100.0",
     "releaseNotes": "1. Fix bug that Biolux Gen I luminaire lost HCL mode occasionally."
   },
@@ -3272,7 +3272,7 @@
     "imageType": 99,
     "manufacturerCode": 4489,
     "sha512": "bfb076e5ba37c99b06b9da01938c165a54f5f5a61559969b27e2ebcccbba31954d176c501346275124fe856e0ebab6660f1276af7de4302046e4dcf91d79fee2",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "Panel_TW_Z3_IM005A_01056400-encrypted_202129091207_withoutMF.ota",
@@ -3282,7 +3282,7 @@
     "imageType": 90,
     "manufacturerCode": 4489,
     "sha512": "4d197641675c06b65e3fde9b65cf805772bb0e249066b74d35644fea1d20c53f967234e8128357b82a8ba960227fe20f2f3bb077a3a1cdfbb30c8e9c53673ad9",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=90&version=1.5.100.0",
     "releaseNotes": "Support ZLO"
   },
@@ -3294,7 +3294,7 @@
     "imageType": 103,
     "manufacturerCode": 4489,
     "sha512": "80ce3557353d90aa106fecb237befd780861dcc710431826444f65c98edb120f5f7517c2bf9b52cce72cadc9f275a2e7f2b963dd3a1c831adadf55acebe58f38",
-    "otaHeaderString": "Plug_Value\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Plug_Value",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=103&version=3.31.115.16",
     "releaseNotes": "(1) Add security patch.\r\n(2) Fix reset button bug in smart outdoor plug."
   },
@@ -3306,7 +3306,7 @@
     "imageType": 45,
     "manufacturerCode": 4489,
     "sha512": "3ebc116780b1b69bed344d94937b1e6280bd7ca477f49958fbb28cbf634f747f4358f307126652ef1c46b94a7f964ccba44e0da62b1acb7a19d10a7f477c7da2",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "RT_RGBW_IMG001D_00102428-encrypted.ota",
@@ -3316,7 +3316,7 @@
     "imageType": 29,
     "manufacturerCode": 4489,
     "sha512": "41c07ffddaa00c8665b4cdef34c34f0a1f1701ad62c6ffee00d5bc408d08865cf163cda2ab382c9770e00bd6c5b296873abc2bfe85f0473d926905c2024c6286",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "RT_TW_IMG001C_00102428-encrypted.ota",
@@ -3326,7 +3326,7 @@
     "imageType": 28,
     "manufacturerCode": 4489,
     "sha512": "deb1f04253eeff026532a9732f9e544847be88d01b866316babea77e1f36d0125cd1033124af15c0cbf5014eb38cc46927165ce0ba99620117d132c6fa1221f7",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "TW_UART_ENERGY-DL_HCL_ND150_02-0x1189-0x00BB-0x02236550-MF_DIS-20230609102634-3221010102432.ota",
@@ -3336,7 +3336,7 @@
     "imageType": 187,
     "manufacturerCode": 4489,
     "sha512": "e1719c9df94e390b00f670fcf1864cad8273fb0554986ffa0281f3fdc76a65bc37304793d937fea7555fd01de69cc8ce5cca8bd9f6780a6ca91ab5b0d04073de",
-    "otaHeaderString": "DL_HCL_ND150_02\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "DL_HCL_ND150_02",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=187&version=2.35.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -3348,7 +3348,7 @@
     "imageType": 188,
     "manufacturerCode": 4489,
     "sha512": "c12b7a8695472aa0c3ebf3e43f504bdbf58c65ef81c137d2718644416214de45054f440eb341c486767f9a4b9fdfaa665575066ad153c56ddbdf50a08a2f863e",
-    "otaHeaderString": "PL_HCL300x1200_01\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_HCL300x1200_01",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=188&version=2.35.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -3360,7 +3360,7 @@
     "imageType": 185,
     "manufacturerCode": 4489,
     "sha512": "23655edfb8be126dd44463e0e4cd7c0cda3e804166ef559a98c2ec8ae70ca0d49a177e2a10f6823af736160aea52f2efb3f983057220abe1f894d69c8cd55ad8",
-    "otaHeaderString": "PL_HCL600_02\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_HCL600_02",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=185&version=2.35.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -3372,7 +3372,7 @@
     "imageType": 186,
     "manufacturerCode": 4489,
     "sha512": "38e3242e350178d74c2447851c5314db9b522ba380dc26850bc66b8fc9fac367afae2e65a62daf398bb5baf06851cc3b2065af7c0782a6dda3709fee712455f2",
-    "otaHeaderString": "PL_HCL625_02\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_HCL625_02",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=186&version=2.35.101.80",
     "releaseNotes": "1. Support GP switch.\r\n2. Improve network performance by fine tune router table."
   },
@@ -3384,7 +3384,7 @@
     "imageType": 44,
     "manufacturerCode": 4489,
     "sha512": "61c9b3727efccff6ba214bda917257e68164c4f276f979d2ac09057be5a9d37129236545022c4c93afc27c2e33a4909f21b8e92cf616795135913f56bcb22b97",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=44&version=1.5.100.0",
     "releaseNotes": "Support ZLO"
   },
@@ -3396,7 +3396,7 @@
     "imageType": 70,
     "manufacturerCode": 4489,
     "sha512": "b2d9f6a1618d68bc97e07a737f02f7b8be4d4f8fc4f08f9e8030c6312b75baa83394490fd37525676102e39e39c59f4003c06521a8b8bbbc727ebf41dcb9f10c",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=70&version=1.5.100.0",
     "releaseNotes": "Support ZLO"
   },
@@ -3420,7 +3420,7 @@
     "imageType": 57374,
     "manufacturerCode": 4364,
     "sha512": "af7d59bf9775eaaa80fbed6d2b19365e29fc3a1cd813dbbab19d6e1dae2293112c64d09ce10436b24c441e27ca6faf44016ae9e79fc81cc93e988e59ad639657",
-    "otaHeaderString": "Zigbee3toDALIConverter\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Zigbee3toDALIConverter",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4364&product=57374&version=16.14.101.91",
     "releaseNotes": "1. Fix bug that endpoint changes.\r\n2. Supportdim down control from push button coupler."
   },
@@ -3804,7 +3804,7 @@
     "imageType": 8347,
     "manufacturerCode": 4447,
     "sha512": "32174d5bc4abbb7295e7619a1684b0a37a9622dfc4cebbc6a39174e18fa3b9bde9b562cbb34e1eb9c61169c0f1f879245d4e452890dfc0645cd22e6ad36f468d",
-    "otaHeaderString": "\u0014OTA_lumi.motion.ac01\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "\u0014OTA_lumi.motion.ac01",
     "modelId": "lumi.motion.ac01"
   },
   {
@@ -3947,7 +3947,7 @@
     "imageType": 4873,
     "manufacturerCode": 4447,
     "sha512": "20955a8996973680d9b1f110c9d5583c072bcb99032a1070fc0c6663323539928d82d46f34a21109e68882272a459d205eecc0ae3b3bae66a8866dc0c2094b2f",
-    "otaHeaderString": "empower mcu\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "empower mcu",
     "modelId": "aqara.feeder.acn001"
   },
   {
@@ -4057,7 +4057,7 @@
     "imageType": 141,
     "manufacturerCode": 4447,
     "sha512": "25007f79ccb030715cd9fa1a0acd447554aa1b8c0627116b0ae06e5135e6c5922e64eace80452e9a05423487d499df1fa0a23a30aead31fac2f15c51f9d82895",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.light.acn132"
   },
   {
@@ -4079,7 +4079,7 @@
     "imageType": 131,
     "manufacturerCode": 4447,
     "sha512": "25a205565f0ba9400cf57e7f633e9fb16fe473d23ac79897269d07ead4a2507a1585abcbb55994be551fbf130c28d4bf34a705d9d7d3083a21e2441cfcbd4a20",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.light.acn003"
   },
   {
@@ -4090,7 +4090,7 @@
     "imageType": 139,
     "manufacturerCode": 4447,
     "sha512": "c0e7a4ea751f2cfb715aee5c3cd4d5cf458f133a76c88e16080a0442652ebb6ae555bcd1336b609a2a9eecc53869d21182fe4b093cc349ef326bf37b6809cf11",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.light.acn128"
   },
   {
@@ -4101,7 +4101,7 @@
     "imageType": 129,
     "manufacturerCode": 4447,
     "sha512": "18b7eb6a76e610645b078103276462991897c02da3825ca92be54dd10260477932eb69300e988b7017e16b74e5c75c707dee56cd9996227de1f252c5fa1aba40",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.light.acn014"
   },
   {
@@ -4112,7 +4112,7 @@
     "imageType": 6028,
     "manufacturerCode": 4447,
     "sha512": "56ecdbb4940e48ab4abeb2ca7a168f23e4c9c116818f842a36b3a28c935a3b8f6e99c42cdef4b2db1dcb9ad2a244548591a1d112d9c37bd4bc568b5c20a3fa07",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.dimmer.acn004"
   },
   {
@@ -4123,7 +4123,7 @@
     "imageType": 138,
     "manufacturerCode": 4447,
     "sha512": "dea351b8a1208cb6703530a78966cc940a5d67c2a8990df18a3fcb7d55304a82d713a656efd27705a8ff51b43028ddef4b765dc3692be2f9cdaf47795ab15b11",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.light.acn024"
   },
   {
@@ -4134,7 +4134,7 @@
     "imageType": 138,
     "manufacturerCode": 4447,
     "sha512": "dea351b8a1208cb6703530a78966cc940a5d67c2a8990df18a3fcb7d55304a82d713a656efd27705a8ff51b43028ddef4b765dc3692be2f9cdaf47795ab15b11",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.light.acn026"
   },
   {
@@ -4145,7 +4145,7 @@
     "imageType": 143,
     "manufacturerCode": 4447,
     "sha512": "e221d3bb6d2a28011463b259ab94e1de40953b2bafd66730b7349e00b88591afe3972f02fea6f8a839d86d92015964976ad61da797de312688696bbeecc718a2",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.light.acn031"
   },
   {
@@ -4156,7 +4156,7 @@
     "imageType": 143,
     "manufacturerCode": 4447,
     "sha512": "e221d3bb6d2a28011463b259ab94e1de40953b2bafd66730b7349e00b88591afe3972f02fea6f8a839d86d92015964976ad61da797de312688696bbeecc718a2",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.light.acn032"
   },
   {
@@ -4178,7 +4178,7 @@
     "imageType": 6169,
     "manufacturerCode": 4447,
     "sha512": "796c6dc424faf0be42aa98482ab178ce3e429a80b47f0ba90ec91d479c6c3205865b666ca57de4814e4e806d1e4bbe8d594956fea30443ba25a67093e46a52be",
-    "otaHeaderString": "lumi.switch.n0agl1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "lumi.switch.n0agl1",
     "modelId": "lumi.switch.n0agl1"
   },
   {
@@ -4200,7 +4200,7 @@
     "imageType": 6424,
     "manufacturerCode": 4447,
     "sha512": "8bed0ef08684be7c182c00bb6226d301e94f73052c997b1adef7ed4379d953c54e870175eca3596e1a5fb3db91ebf8bacd6fa9d9ba65eb3c00556ff2406c1622",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.switch.acn059"
   },
   {
@@ -4211,7 +4211,7 @@
     "imageType": 6424,
     "manufacturerCode": 4447,
     "sha512": "8bed0ef08684be7c182c00bb6226d301e94f73052c997b1adef7ed4379d953c54e870175eca3596e1a5fb3db91ebf8bacd6fa9d9ba65eb3c00556ff2406c1622",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.switch.acn058"
   },
   {
@@ -4222,7 +4222,7 @@
     "imageType": 6424,
     "manufacturerCode": 4447,
     "sha512": "8bed0ef08684be7c182c00bb6226d301e94f73052c997b1adef7ed4379d953c54e870175eca3596e1a5fb3db91ebf8bacd6fa9d9ba65eb3c00556ff2406c1622",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.switch.acn057"
   },
   {
@@ -4233,7 +4233,7 @@
     "imageType": 6424,
     "manufacturerCode": 4447,
     "sha512": "8bed0ef08684be7c182c00bb6226d301e94f73052c997b1adef7ed4379d953c54e870175eca3596e1a5fb3db91ebf8bacd6fa9d9ba65eb3c00556ff2406c1622",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.switch.acn056"
   },
   {
@@ -4244,7 +4244,7 @@
     "imageType": 6424,
     "manufacturerCode": 4447,
     "sha512": "8bed0ef08684be7c182c00bb6226d301e94f73052c997b1adef7ed4379d953c54e870175eca3596e1a5fb3db91ebf8bacd6fa9d9ba65eb3c00556ff2406c1622",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.switch.acn055"
   },
   {
@@ -4255,7 +4255,7 @@
     "imageType": 6424,
     "manufacturerCode": 4447,
     "sha512": "8bed0ef08684be7c182c00bb6226d301e94f73052c997b1adef7ed4379d953c54e870175eca3596e1a5fb3db91ebf8bacd6fa9d9ba65eb3c00556ff2406c1622",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.switch.acn054"
   },
   {
@@ -4266,7 +4266,7 @@
     "imageType": 6424,
     "manufacturerCode": 4447,
     "sha512": "8bed0ef08684be7c182c00bb6226d301e94f73052c997b1adef7ed4379d953c54e870175eca3596e1a5fb3db91ebf8bacd6fa9d9ba65eb3c00556ff2406c1622",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.switch.acn049"
   },
   {
@@ -4277,7 +4277,7 @@
     "imageType": 6424,
     "manufacturerCode": 4447,
     "sha512": "8bed0ef08684be7c182c00bb6226d301e94f73052c997b1adef7ed4379d953c54e870175eca3596e1a5fb3db91ebf8bacd6fa9d9ba65eb3c00556ff2406c1622",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.switch.acn048"
   },
   {
@@ -4426,7 +4426,7 @@
     "imageType": 6416,
     "manufacturerCode": 4447,
     "sha512": "a135dcf96e1086d30e945cb3b40885fce60840b98ca6dee595dbed97e702e3583336d21948a19f37d20a942ac9daa84abc57da39465611ff86628d825ce6f5c0",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "originalUrl": "https://cdn.aqara.com/cdn/opencloud-product/mainland/product-firmware/prd/lumi.switch.acn047/20240830115847_OTA_lumi.switch.acn047_0.0.0_0032_20240823_D8294E.ota",
     "modelId": "lumi.switch.acn047",
     "releaseNotes": "1.Fix known bugs"
@@ -4835,7 +4835,7 @@
     "imageType": 1409,
     "manufacturerCode": 4447,
     "sha512": "c830f68703a1556c619000b8b67c055676953d40ac32090f3ca4fa8abc7c30902614a2890dcd926b9e8d496be769e103ef32c40c9dbbc4caec15417d00465de6",
-    "otaHeaderString": "lumi.switch.n0acn2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "lumi.switch.n0acn2",
     "modelId": "lumi.switch.n0acn2"
   },
   {
@@ -4857,7 +4857,7 @@
     "imageType": 103,
     "manufacturerCode": 4644,
     "sha512": "a26bc37b7dfad1fa473eef13677505df70ec6ae5e3012351dec1344bac53756b4423ae2fbfdb21056b11da8b762455df15481500f7b505f5e2892c33629e0a21",
-    "otaHeaderString": "4512700\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "4512700"
   },
   {
     "fileName": "4512703-Firmware-35.ota",
@@ -4867,7 +4867,7 @@
     "imageType": 1008,
     "manufacturerCode": 4644,
     "sha512": "b4d6e2ee31ad7a90ec0d87d3a00ca08a587ac5ca276484a2ffdc8ff94dcb6b63199f679e6659a2b5217aa4a6bf067c8bc10692ca541ddec354184939a673cb71",
-    "otaHeaderString": "4512701&4512703&4512719\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "4512701&4512703&4512719",
     "modelId": "4512703"
   },
   {
@@ -4878,7 +4878,7 @@
     "imageType": 2004,
     "manufacturerCode": 4644,
     "sha512": "0aeb77ba2d00b84af63582a3c71e98fda84f9bfdd079a19c203e34b18ff1f722417484e03e0be841793c14f9e3eb50e77412f4918d3b50ada1c1e85bba4c2d7a",
-    "otaHeaderString": "4512704\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "4512704",
     "modelId": "4512704"
   },
   {
@@ -4889,7 +4889,7 @@
     "imageType": 1008,
     "manufacturerCode": 4644,
     "sha512": "b4d6e2ee31ad7a90ec0d87d3a00ca08a587ac5ca276484a2ffdc8ff94dcb6b63199f679e6659a2b5217aa4a6bf067c8bc10692ca541ddec354184939a673cb71",
-    "otaHeaderString": "4512701&4512703&4512719\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "4512701&4512703&4512719",
     "modelId": "4512705"
   },
   {
@@ -4900,7 +4900,7 @@
     "imageType": 1008,
     "manufacturerCode": 4644,
     "sha512": "b4d6e2ee31ad7a90ec0d87d3a00ca08a587ac5ca276484a2ffdc8ff94dcb6b63199f679e6659a2b5217aa4a6bf067c8bc10692ca541ddec354184939a673cb71",
-    "otaHeaderString": "4512701&4512703&4512719\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "4512701&4512703&4512719",
     "modelId": "4512719"
   },
   {
@@ -4911,7 +4911,7 @@
     "imageType": 1008,
     "manufacturerCode": 4644,
     "sha512": "af27753c8e1c53e38f3330e161143f01492a9d124156a9e1a8ead138143695e1496a5d0266494892e8a6d1055f6b8a7272ea5327d6d8061ba4be94f74c39c418",
-    "otaHeaderString": "4512721&4512728&4512729\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "4512721&4512728&4512729",
     "modelId": "4512721"
   },
   {
@@ -4933,7 +4933,7 @@
     "imageType": 1008,
     "manufacturerCode": 4644,
     "sha512": "af27753c8e1c53e38f3330e161143f01492a9d124156a9e1a8ead138143695e1496a5d0266494892e8a6d1055f6b8a7272ea5327d6d8061ba4be94f74c39c418",
-    "otaHeaderString": "4512721&4512728&4512729\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "4512721&4512728&4512729",
     "modelId": "4512729"
   },
   {
@@ -5035,7 +5035,7 @@
     "imageType": 6001,
     "manufacturerCode": 4644,
     "sha512": "ce40cfc670692384590fc58b84fd9b0d1a6f7b1fa28c6a34ea46fd404b536135151e0fa70bef5ff0c1eeca3fe0d27174806fd1b4863e5bc10afaeca49e0b14f0",
-    "otaHeaderString": "Encrypted GBL Z3_HVAC_Router\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Encrypted GBL Z3_HVAC_Router",
     "modelId": "4512737"
   },
   {
@@ -5046,7 +5046,7 @@
     "imageType": 6002,
     "manufacturerCode": 4644,
     "sha512": "c6eb11b68bbbacee5ee8dc483a93d07db60003a8345fdd512e05603b9ab1b3dd06f692e01a3be71f3411fdd43a3446198fc7dc806c9b80cab3c86226a41941a7",
-    "otaHeaderString": "Encrypted GBL Z3_HVAC_Router\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Encrypted GBL Z3_HVAC_Router",
     "modelId": "4512738"
   },
   {
@@ -5057,7 +5057,7 @@
     "imageType": 2,
     "manufacturerCode": 4747,
     "sha512": "5353005ba068d46aa3c32aa31a1e4958c801e467f65ada46fe438a4f70402c711a7ce22ac5fe3f0b3882b3d8222b08dd43d89fca3babdc30f38121b625b96f04",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0005-0305-700_nodon_sin_4_1_21_fw_V0305.zigbee",
@@ -5067,7 +5067,7 @@
     "imageType": 5,
     "manufacturerCode": 4747,
     "sha512": "a5eaf2e4faf5b2ce3330f51ee738a65499209cf754784b025626f683c95b7b018a57b6fb55ff47ff86de5ca7dcf7f1a36ada0307252c4119368c5c7bad125261",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0006-0305-700_nodon_sin_4_fp_21_fw_V0305.zigbee",
@@ -5077,7 +5077,7 @@
     "imageType": 6,
     "manufacturerCode": 4747,
     "sha512": "9ed0f44d8cd338a53e9be2b9fe136213e9a8ff886f78d94fe992b02ef6fee412fe58c6145c2facf2bf5b516b7d000e8997ee5b680d7c2acf5ff96fdb15d4a82e",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0009-0305-700_nodon_sin_4_rs_20_fw_V0305.zigbee",
@@ -5087,7 +5087,7 @@
     "imageType": 9,
     "manufacturerCode": 4747,
     "sha512": "88bdfeadcbae70c3fe541f98af1dfbd9b437600ede7d7d27ca8e21a5b6e86dc8fa6ffbf9921cafda9a0f19809e909d1126b71cc221b53e39f5f62d252e4e407e",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-000A-0305-700_nodon_sin_4_1_20_V0305.zigbee",
@@ -5097,7 +5097,7 @@
     "imageType": 10,
     "manufacturerCode": 4747,
     "sha512": "95d2b3dbcf41e5212e63ff92270a9fa8ebb1cdabf84b3fa94bc4207bd55ce86ac4e110c1c150d78affef2d003ad4a306ad5947a55705d1ff1637cc4df3df29cf",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0102-10101-700_nodon_sin_2_fm_stm32_V10101.zigbee",
@@ -5107,7 +5107,7 @@
     "imageType": 258,
     "manufacturerCode": 4747,
     "sha512": "4e9eaa29e4bd1277595d6bc779f4f45b9e70dc5407d7fe200c08884e533e0f377f054021cfb89c7e6fad5ffd1dcd35ec22ae90e39ebc94874c95ab2acdb2e77c",
-    "otaHeaderString": "nodon_sin_stm32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_stm32_ota"
   },
   {
     "fileName": "128b-0105-010500-700_nodon_sin_xx_met_fm_stm32_V010500.zigbee",
@@ -5117,7 +5117,7 @@
     "imageType": 261,
     "manufacturerCode": 4747,
     "sha512": "fc47d5f4e6a709cf3ced8b0cbc97dce6f7626a185ea86f807827afd29c87a380ba4f9bbc200f7a19f41033e4d1609ffc2c77f0ac4fe486c6756fa7cfe1b0713e",
-    "otaHeaderString": "nodon_sinMet_stm32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sinMet_stm32_ota"
   },
   {
     "fileName": "128b-0106-010500-700_nodon_sin_xx_met_fm_stm32_V010500.zigbee",
@@ -5127,7 +5127,7 @@
     "imageType": 262,
     "manufacturerCode": 4747,
     "sha512": "214f6e1793a739a1822ddbe53a5c68a32b0ee48ba19fff974b8e607bfaea4baeb3596dde070e7aec06e0a7eddad25a67db62ee8a7396c77fe5ac71f34e7fb35a",
-    "otaHeaderString": "nodon_sin_stm32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_stm32_ota"
   },
   {
     "fileName": "128b-0109-10102-700_nodon_sin_rs_fm_stm32_V10102.zigbee",
@@ -5137,7 +5137,7 @@
     "imageType": 265,
     "manufacturerCode": 4747,
     "sha512": "54f663c338f26aa89245edc79bbbdc911763897f2ca6ba92d72ce447f03f23d0d33a669af68e87ef84d95fa0df0231441f56fc45cb768a5e12ca2f1e77c2f1b9",
-    "otaHeaderString": "nodon_sin_stm32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_stm32_ota"
   },
   {
     "fileName": "128b-010A-010500-700_nodon_sin_xx_met_fm_stm32_V010500.zigbee",
@@ -5147,7 +5147,7 @@
     "imageType": 266,
     "manufacturerCode": 4747,
     "sha512": "d866e1dd0614b33a8d24b0d66228d53f4cca93c26a2613f75dcf73edb311e7bf6e3c791fae93c3b9633a4c40dbb6380aee5e6134fdfb9cee7bce70386fb7eb1d",
-    "otaHeaderString": "nodon_sin1_stm32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin1_stm32_ota"
   },
   {
     "fileName": "128b-2002-040300-700_p2022_HSP_tphu_fw_efr32_V040300.zigbee",
@@ -5157,7 +5157,7 @@
     "imageType": 8194,
     "manufacturerCode": 4747,
     "sha512": "ef49e08f08c592887d2cbc24ca95c3e9ee8e9396be1e32dec66b919075b302680954383eb2465da9023faf7ab88078884b9d8cd59d17c8261a4cf4e05ce4e428",
-    "otaHeaderString": "p2022_HSP_tphu_fw_efr32\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "p2022_HSP_tphu_fw_efr32"
   },
   {
     "fileName": "128b-2003-040300-700_p2022_HSP_do_fw_efr32_V040300.zigbee",
@@ -5167,7 +5167,7 @@
     "imageType": 8195,
     "manufacturerCode": 4747,
     "sha512": "aa642f6949ae15848a2ce0ba5f46867caf6dda4e04d46e116fd5df0cf7d7db324d0150cfd3ee43db0245e491756c100051217e5aba4c8c5709780c2c2f9378ad",
-    "otaHeaderString": "p2022_HSP_do_fw_efr32\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "p2022_HSP_do_fw_efr32"
   },
   {
     "fileName": "128b-2004-040300-700_p2022_HSP_dc_fw_efr32_V040300.zigbee",
@@ -5177,7 +5177,7 @@
     "imageType": 8196,
     "manufacturerCode": 4747,
     "sha512": "11344fa4dce9633aba9a83a49d48fea2cd1f7aa0c9622e783bd3df345b41b564bd9db0c600845a69170c59e1c1c1f37416cf429c7257e58cd942033ecb6fd995",
-    "otaHeaderString": "p2022_HSP_dc_fw_efr32\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "p2022_HSP_dc_fw_efr32"
   },
   {
     "fileName": "128b-4002-010600-nodon_irb-4-1-00_fw_V010600.zigbee",
@@ -5187,7 +5187,7 @@
     "imageType": 16386,
     "manufacturerCode": 4747,
     "sha512": "d2a350be20dd1d3c46a1d26d505b6dbbe5c6fd0894d048f99cd09946ed109163bab8883cded8a9882af6f19dff726232cc2c1066b26ea98b131b7b4d53d9d717",
-    "otaHeaderString": "EBL Remotec_IR\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL Remotec_IR"
   },
   {
     "fileName": "ZLL_MK_0x01020509_CLA60_TW.ota",
@@ -5197,7 +5197,7 @@
     "imageType": 8,
     "manufacturerCode": 4364,
     "sha512": "1cba1e813a0264143e082c9288922309b098c2490548b74a6f63bd2703057afab2f80b16500805417b20ad2c02746cd64c17e3a91c0f338c5dac051a23e43c37",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_CEILING_TW_OSRAM.ota",
@@ -5207,7 +5207,7 @@
     "imageType": 107,
     "manufacturerCode": 4364,
     "sha512": "3222b2998a5d587db758fd0ea0185cb0c60324276e30227828d976d469b5ee7461ccc7ccf24e7e9fc7790352e94bf547ff85a44b341a9ce80356c5ba737af1a4",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_CLA60_RGBW_OSRAM.ota",
@@ -5217,7 +5217,7 @@
     "imageType": 98,
     "manufacturerCode": 4364,
     "sha512": "f48a5a3b4d0e636e40e82b219eb6ab64431b98b92ad0737a4de42193d64dd5638d38c13273835b2f0959be98b424c0a6ee47c3eb8b7aa18de11d96e84ad5b0d5",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_CLA60_TW_OSRAM.ota",
@@ -5227,7 +5227,7 @@
     "imageType": 99,
     "manufacturerCode": 4364,
     "sha512": "c084961dd6117cfd1dc1dab4fd99e6f95c3f0fb2a6b9a847acd52e7b2ab091b32800898477d04871db32cfc7c96eec5afdbf4564cc27ca63283bbeeaec63d06f",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_CLA60_W_CLEAR.ota",
@@ -5237,7 +5237,7 @@
     "imageType": 19,
     "manufacturerCode": 4364,
     "sha512": "7f4bb423aed7d3d81a43c054897796f76e05c049911fee9ffc36d4c4a4baa44369bb35a8d44d8e3630e26ec65a3a59e5ada97d75109887422c7e6a75b2a9bcf5",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_CLASSIC_A60_RGBW.ota",
@@ -5247,7 +5247,7 @@
     "imageType": 6,
     "manufacturerCode": 4364,
     "sha512": "dbdab10f00722f7b9be2b7b4e6ce8302edee2ad02c9b75da9adf754779ad003ed8f5b07225ea547be14c600989baae56cf1e420b11b264d8c31d3f856e5a9892",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_CLASSIC_B40_TW.ota",
@@ -5257,7 +5257,7 @@
     "imageType": 20,
     "manufacturerCode": 4364,
     "sha512": "2faa40b833154aaee844b6ab6e393c76b327b1122bb88ae6f3036d95858cfdcdae35fad7c5f6578c166be25fe6978eb02858ae4e09c955debcf26b11b23b79de",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_FLOOD_LIGHT_RGBW_OSRAM.ota",
@@ -5267,7 +5267,7 @@
     "imageType": 108,
     "manufacturerCode": 4364,
     "sha512": "a3b64a5183bc23617afa528edffbe83721547f203f3eca3f043c39d42eacee94cd0a15f8096c136d3c738dd87945f15f9822b0ba265249e1892e739a2b491904",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_GARDENPOLE_MINI_RGBW_OSRAM.ota",
@@ -5277,7 +5277,7 @@
     "imageType": 103,
     "manufacturerCode": 4364,
     "sha512": "c2eabeb89c104b3d398ac9bcd8ff7f8a10eb2e6352050f0404939f7b6c7391ea005b1975ff3e8367775ce2f4b40a1fc197b390564e75389e71f61a2f6d3b7a5e",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_GARDENPOLE_RGBW_LIGHTIFY.ota",
@@ -5287,7 +5287,7 @@
     "imageType": 90,
     "manufacturerCode": 4364,
     "sha512": "35242c676acf7426fbe89562a5199a665778ef95a2e001141fd5d4927e3a8d3724c0cea5874f36cefdb536bbae3356dd99bff8e6a3666c6205141e3d34d66f57",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_GARDENSPOT_RGB.ota",
@@ -5297,7 +5297,7 @@
     "imageType": 5,
     "manufacturerCode": 4364,
     "sha512": "20f450221e2915f84dc9ac50d3649f8df219240a35a770c2185d270ccfd4619968f8fe82cb917e181b1e688c6ea6623dc59798575716d2af7f0f660842ca6821",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_GARDENSPOT_W.ota",
@@ -5307,7 +5307,7 @@
     "imageType": 7,
     "manufacturerCode": 4364,
     "sha512": "dab7a5430e9a1bd12d15b0a524c0d715ba3de5800fe528478ccdd147a6923fcbe85fa124f0afd120a9a8e4f2d6f458763c88cd58dc1716d44040665a4ccc034d",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_LIGHTIFY_INDOOR_FLEX.ota",
@@ -5317,7 +5317,7 @@
     "imageType": 92,
     "manufacturerCode": 4364,
     "sha512": "c40a4c6a58409f325d1409536737b11bdbb6ffd1176d67aea0423778af8b513c4663d8ece9666363950b12e24507d2a8ff345645eb62ca2e881223b94cb3c42f",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_LIGHTIFY_OUTDOOR_FLEX.ota",
@@ -5327,7 +5327,7 @@
     "imageType": 91,
     "manufacturerCode": 4364,
     "sha512": "b21e18b34bb70d9904adf05e2697769760ada4c1b1ed30aa8c647e99442c35090727f35e823e3dad16ea1593967c790c683895f1c33184eb80055cf322e640ab",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_MR16_TW_OSRAM.ota",
@@ -5337,7 +5337,7 @@
     "imageType": 101,
     "manufacturerCode": 4364,
     "sha512": "c3773bcba343db437a051be87cbdfb4055412875760d00257e0fc74b7d34d13b496b078d6b0211013101a358f3d5bf3fee17fb6c84a175662b147b32e15f9b62",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_OUTDOOR_LANTERN_B50_RGBW_OSRAM.ota",
@@ -5347,7 +5347,7 @@
     "imageType": 105,
     "manufacturerCode": 4364,
     "sha512": "032d9bfa1155bc78b5c010070f0b89e26227da3ada96cec9edb83ad783c2babcad4ec5ab9d8ab8491768e0826effa6f051d5206492dda9669002fdef0320cb97",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_OUTDOOR_LANTERN_B90_RGBW_OSRAM.ota",
@@ -5357,7 +5357,7 @@
     "imageType": 110,
     "manufacturerCode": 4364,
     "sha512": "8f54df92306ebd864022d368fbb00f87d33c04111c2482e436564a778cc4d3de3c129a355a712d96c028c3ff599134bbf9cfdd41386e2e767e8814b72b9e948b",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_OUTDOOR_LANTERN_W_RGBW_OSRAM.ota",
@@ -5367,7 +5367,7 @@
     "imageType": 104,
     "manufacturerCode": 4364,
     "sha512": "7674274798b0eab2f4023f0732f56fdcf131c108ed1080f8a752aa58542839edae468980c51dddf87a1452c331e4bd1f793bb792c2d6e73a4183e792e478f4a8",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_PANEL_RGBW_OSRAM.ota",
@@ -5377,7 +5377,7 @@
     "imageType": 106,
     "manufacturerCode": 4364,
     "sha512": "0fdc276f1620a676118245f7744a1cb079e5ac5686106d29c744e6aa6b494421dcf438ff12212723844f95b82612ad837275b7f8c67b8403eb11b39ee3bc03af",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_PAR16_50_TW.ota",
@@ -5387,7 +5387,7 @@
     "imageType": 3,
     "manufacturerCode": 4364,
     "sha512": "ce267106c201cfca6f94e1fdfa4a256bdd8eede8610bc0f5ccebbc70c5df50acf37d71f1779fd454069a6708caa2c858c6510bc627ced7b60b9dcb05bceab240",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_Par16Rgbw.ota",
@@ -5397,7 +5397,7 @@
     "imageType": 17,
     "manufacturerCode": 4364,
     "sha512": "e19e81931f7716a02aabbe696630d5bf48e13ec46f4fd1353c59ff29f683ca44ff5b8417387b1e811e3db32a1b2dcc87d88989874de08790ed304410bd7c322c",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_Surface_Light_TW.ota",
@@ -5407,7 +5407,7 @@
     "imageType": 4,
     "manufacturerCode": 4364,
     "sha512": "e11551fedbf0617d1133fd4cbc03a05231569ebc3ff006fd49a1e2fc7e6821eaf6d5f4bb19d39381e67f13c74caf3269b8ae42c49e3accadc4a0b029d2cd625d",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_MK_0x01020510_Surface_Light_W.ota",
@@ -5417,7 +5417,7 @@
     "imageType": 9,
     "manufacturerCode": 4364,
     "sha512": "83c54292e2da84e377175f06dc3860028cc37676b51e6669d13a888ff2bdf1545cf215c8990fd6915bbb3359a450c10cd03a30108366fc8b2ccbb60588c1ca69",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_Plug01_OnOff_MK_0x01020509.ota",
@@ -5427,7 +5427,7 @@
     "imageType": 39,
     "manufacturerCode": 4364,
     "sha512": "65aa917e46d1f31cc1a148a2d0cbe9d24bac3267deb6d6567e27f584b9124ca0fabe0d2be26aa185461605194c1ab0ab68a99dd0e71148e35e21ddc4815e2d21",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "ZLL_SubstiTube_W_MK_0x01020509.ota",
@@ -5437,7 +5437,7 @@
     "imageType": 46,
     "manufacturerCode": 4364,
     "sha512": "2b5de5c152ea81b5cd0f565b325703edfa2e781911366b2f462b982001885876663cab1f7635eba7b6972fea8ba9fc55a1bcad43c7fc5653c2c22a78bd0b2a86",
-    "otaHeaderString": "NULL\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "NULL"
   },
   {
     "fileName": "LDS_MotionSensor_1168-0402-41030002.zigbee",
@@ -5447,7 +5447,7 @@
     "imageType": 1026,
     "manufacturerCode": 4456,
     "sha512": "e0cc45970c75311a3a4b0f592c023583f8224d6ca0b2c0612539131b7210e095903fd139c50c4f54c9f97b4b40bd0e0637969aa54b229dbba00e1e40333a4edc",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "modelId": "ZHA-PirSensor"
   },
   {
@@ -5469,7 +5469,7 @@
     "imageType": 47,
     "manufacturerCode": 4216,
     "sha512": "81e9a7d13a7ea5ae72b8a3fedc4d1df4133775b9bf7c0ecdf778ed8a63816553fabb342b4353cef7d38925c89160549eb653219149af98e50ba812b11ff86c83",
-    "otaHeaderString": "image build\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "image build",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/00f1cffd-2aa9-4f5e-8503-59beddc86ba3/CSB600_20170209.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5483,7 +5483,7 @@
     "imageType": 37,
     "manufacturerCode": 4216,
     "sha512": "8fa0103ba223f257e8de01a2bd2e4edd571a3e3f2056a788f50679f29a5bc73ae120ae24c0fad3e640cee1a53a7c6fafdec5efae27139be9a9371c77b083e66c",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/AN2X0Z_xsQeexhO012ZUUbFdDk5QFVECSHNGH4oWm20/ECM600_09160525.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5497,7 +5497,7 @@
     "imageType": 8320,
     "manufacturerCode": 4619,
     "sha512": "aeaf6f9e27df16b3d2eb398c457448bdfc88a65cf668884f7ce99eb94a2a5bf8a995e0906b595071fc8c069b4ec5e946a20f05ae4f613d7616d45553497a5c42",
-    "otaHeaderString": "General Upgrede File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "General Upgrede File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/1deaffef-7a69-4579-93f8-351a8df644d8/SmokeSensor-EM_00000014.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5511,7 +5511,7 @@
     "imageType": 0,
     "manufacturerCode": 4388,
     "sha512": "57f2774b28229f81a83415ca9e51a89ddfcedec527beb5b582e5ff72d45ef5295ba14ab54f077c62e5b1b92870bcaa6a2b5d02cd3ba830dbacc395f7421794b9",
-    "otaHeaderString": "Jasco 45857 image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Jasco 45857 image",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/3319b501-98f3-4337-afbe-8d04bb9938bc/45857_00000006.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5525,7 +5525,7 @@
     "imageType": 2,
     "manufacturerCode": 4388,
     "sha512": "3306332e001eab9d71c9360089d450ea21e2c08bac957b523643c042707887e85db0c510f3480bdbcfcfe2398eeaad88d455f346f1e07841e1d690d8c16dc211",
-    "otaHeaderString": "Jasco 45856 image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Jasco 45856 image",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/a65779cd-13cd-41e5-a7e0-5346f24a0f62/45856_00000006.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5539,7 +5539,7 @@
     "imageType": 55,
     "manufacturerCode": 4216,
     "sha512": "b2940f263757fefb5f4f80a5a1c1d7ac8ffd56954c2350782a99444cfb71d23253f6a7f7dcb102cacf0412bd0eeb2a792036bc3ab54a8e023f8a6aa09e6b40c9",
-    "otaHeaderString": "SAA6SK(J)1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "SAA6SK(J)1",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/206b5a66-cca9-4886-95cd-1f1278bb293d/IT600PumpWC_20170614.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5553,7 +5553,7 @@
     "imageType": 62,
     "manufacturerCode": 4216,
     "sha512": "c837f2ec9f4deaddbb94adfa60b9d85fe9de59d760b10a968ff97356b174118d05b0f3bcfe961604a9c964ac3fb55346643a87145aca2d4777f7e07a7aad59f2",
-    "otaHeaderString": "Repeater\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Repeater",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/777f6d6a-b55c-4536-89ef-4c96eac79854/RE600_20190415.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5567,7 +5567,7 @@
     "imageType": 70,
     "manufacturerCode": 4216,
     "sha512": "f76716c7f615afba13d57df08d7b01fefe5995a00f91768f42dfe81a56470800208665ed5fb3b3cdc88bef09ed41632455f50c4a47b05600308d3481f0521fd1",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://ec2-18-194-20-66.eu-central-1.compute.amazonaws.com/firmware/UG-SYS/WRT/2023-0629/AWRT10RF_00060962.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5609,7 +5609,7 @@
     "imageType": 61,
     "manufacturerCode": 4216,
     "sha512": "3dfcccb36767ddb07dac12fc8170b8452d682cbbb523ffe0f2c7adbec8a984b0fd492607427f858615a59d1ebf1f98d37378475da1f38558e028eaab0728f195",
-    "otaHeaderString": "SR600\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "SR600",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/a6ab008c-d375-4ce4-a083-d1b152cbd571/SR600_20190415.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5623,7 +5623,7 @@
     "imageType": 75,
     "manufacturerCode": 4216,
     "sha512": "92943e8156981049b536016cc6c27b0d5b7d1401e939633e5e15032d98c06e59d8ac5a74d45e7933b593b3c55bb3fd009a5b31a7bcc8726d6422c906780ce6c9",
-    "otaHeaderString": "EBL WaterBugSensor\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL WaterBugSensor",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/3ea71e61-bbf7-4b93-a3b3-127ea6c3407f/WLS600_20181214.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5637,7 +5637,7 @@
     "imageType": 19,
     "manufacturerCode": 4216,
     "sha512": "625da57746569197b61f92e15512dbbc409ae60290dc98866eb39fc2aa4c2c2ad9441ff14511332745fb5a7bec36b71a0ac373c83a35cf206ed7e9dd8e9cd708",
-    "otaHeaderString": "SAL6DB1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "SAL6DB1",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/315e4681-e0c8-44ff-bb77-f0bf0629203c/it600Receiver_20190410.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5651,7 +5651,7 @@
     "imageType": 44,
     "manufacturerCode": 4216,
     "sha512": "c319412eec498d890ec5bc43a9e1ccb0ec0fbc942cff08d867be36718a57e3d9abfa4aa97677214a13e1270c418d14ea40e20b22ea210d3818ed760141b5bb3d",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/36ab7f9e-6497-4efa-8ece-efb645af9128/FC600_003E0029.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5665,7 +5665,7 @@
     "imageType": 138,
     "manufacturerCode": 4216,
     "sha512": "2cbbbd01f15b73c939f1ae4e48ab116f8567434d63cafa8d8d9bcb2aac65935f01a1017ab0f86b2a464065daba8cd612a5cd71bb396a5625e32c585e9e7b50fa",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://ec2-18-194-20-66.eu-central-1.compute.amazonaws.com/debug/OTA_Test/FC600NH/FC600NH_0066003E.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5679,7 +5679,7 @@
     "imageType": 17,
     "manufacturerCode": 4216,
     "sha512": "3a1aff87a716a06d562b00eaad6f6c271a68dd7eb0256773f9568708e1f2112577ce3e2b2e37fdfabc2f061cb2ef58f957129bf212d851e66c9d5183e8315397",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/7c6f40e8-c433-4976-bc05-fa4de99ec4bf/it600HW-AC_009A74A4.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5693,7 +5693,7 @@
     "imageType": 18,
     "manufacturerCode": 4216,
     "sha512": "8d370d10b99495e8dd14795dc3ce9185a6d0a653ce10b0c6352c898b7706590703c31309365c2566020c187a130781a9ca7b4a0dea41ec5cde52b9e0af900a68",
-    "otaHeaderString": "EBL IT600_Tstat\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL IT600_Tstat",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/8a2d1183-9af1-46c5-b760-64824b11b920/it600WC_20230222.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5707,7 +5707,7 @@
     "imageType": 27,
     "manufacturerCode": 4216,
     "sha512": "667d520a968e5205ec1e427b696da1895c24ece53993ecdbc6f4c67845b34a1e2ca52fbba5b345007178c75948bda703bd3ea0224f8d08b49c120345dbd724f7",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/448bbf25-0ec6-4639-8755-bd614fea203d/it600MINITRV_00910040.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5721,7 +5721,7 @@
     "imageType": 16,
     "manufacturerCode": 4216,
     "sha512": "477be966bee03ccaa28f7d3994f259d7833db7fea82c9e82d7136dabfa9967da1503914d73f4972f60c9fba423a89f99473468ec9b5e5d62b3139c55f7a886b9",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/c0f1f26c-fe08-400d-ba6a-b04e8dd77413/it600HW_009A50A4.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5735,7 +5735,7 @@
     "imageType": 20,
     "manufacturerCode": 4216,
     "sha512": "cc6d5ec80ab6ae113243c7874beb5864ad87c6c13cc52e162387b1c5c4eca17f56d0e073ef7222ac7d3b5d05e413e058183db94062faac8f33d89a11f730945a",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/4d6f705a-b2c5-4a7c-b1e3-e7f7480dd31a/it600TRV_005F004F.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5749,7 +5749,7 @@
     "imageType": 76,
     "manufacturerCode": 4216,
     "sha512": "f14f6895ebf681b0345613c591cff0972b5a9898fc5f5006b1999431706a875e989a960e757426ad5ef7818255eba3686e0274ec3d561c71c9e17dc0df75a2d5",
-    "otaHeaderString": "EBL RollerShutter\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RollerShutter",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/aa8c3733-72bb-4bcf-8500-1a93bfde2fc2/RS600_20190612.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5763,7 +5763,7 @@
     "imageType": 123,
     "manufacturerCode": 4216,
     "sha512": "480bb667a5345da8cf057b3952f305b8a442c4bd6be952935faa4d37be1bfb0b17d71273f83fef53bfc676e1cccb7d0f60225debadd38886dfb25bd63c49d582",
-    "otaHeaderString": "SQ610\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "SQ610",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/1b0ed51a-5a02-423c-8e93-fc124110546c/SQ610NH_00000048.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5777,7 +5777,7 @@
     "imageType": 122,
     "manufacturerCode": 4216,
     "sha512": "bac59af2a8daefae4a4cff84e8721872e4847063290ac315e2998a479bfdc207e3e25dfc7d0127b2c2b2ba11588676c56ff21c8b73159681e96cfcde29017310",
-    "otaHeaderString": "SQ610RF\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "SQ610RF",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/357da06e-3c53-41fe-9d6c-e75b67f46c15/SQ610RFNH_00000046.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5791,7 +5791,7 @@
     "imageType": 40,
     "manufacturerCode": 4216,
     "sha512": "08fa85778408631612bc2ea0df6ad18cd1cba530c5b10ab387743daad00cbda41eb7304ee4050714c76c48c563259ee3324687aaa0f79be9e6480092cc9c36dc",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/4737e511-6fbc-465a-9581-2610d31c71aa/ST898ZB_0064004E.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5805,7 +5805,7 @@
     "imageType": 82,
     "manufacturerCode": 4216,
     "sha512": "eea5e7dd0b6c88e21c6aca8ff68d2dbabd864cd5bdd32432c39a80854c5dc232ea94575861f0f7b24334a5bd5e324049f37bbb808c106bd58d1d656ac9c6ffaa",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/6ed08ad1-9a09-47cc-8b0d-40cf4709c853/ST899ZB_00270009.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5819,7 +5819,7 @@
     "imageType": 89,
     "manufacturerCode": 4216,
     "sha512": "f601e84bb7d831faba15c5e252529401f70c87a6bb9e8f5cd3fe84c2daea0bc187d9c9c44e4fc7ff4d0930d09506b697c7f9e8911dad72e9a85dca0752314361",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/88179668-8112-4ce0-af1b-266a1d8adc08/ST898ZBR_00640050.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5833,7 +5833,7 @@
     "imageType": 36,
     "manufacturerCode": 4216,
     "sha512": "78c13fb0ba5350b03beb33a704ad0abbc4c61c54613989747a301571607b60f78e1580417c4acd765b87953d451a5d64297f89d9d9ee167d43cab561813e7812",
-    "otaHeaderString": "SAU2AD1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "SAU2AD1",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/4a1d7cf3-75b5-46eb-93bc-f38dc1c0f8c8/SS881ZB_20170211.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5847,7 +5847,7 @@
     "imageType": 21,
     "manufacturerCode": 4216,
     "sha512": "af72dc9e4e07649550673c86c2491a9fa6b4e0ad0930ea1fcabfb036dc1f39134673b2249f6361a4f128092feb85a50c4e305c3d2413b1fafc8d7158c59d920e",
-    "otaHeaderString": "SAU2AG1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "SAU2AG1",
     "originalUrl": "http://ec2-18-194-20-66.eu-central-1.compute.amazonaws.com/firmware/UG-SYS/UG600/ZC/SAU2AG1-ZC_20240531.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5861,7 +5861,7 @@
     "imageType": 32,
     "manufacturerCode": 4216,
     "sha512": "be85661199e446f335f47eb0c273078eaed939de0f3a6244b2b7984c82468c42c96b926e4383b674aff67a733d26f9618b82073d5d472965582b3ffa20f75e81",
-    "otaHeaderString": "SAU2BD1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "SAU2BD1",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/dedf71b6-9da3-4c4c-aa5b-bd5b29253ada/SS882ZB_20170206.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5875,7 +5875,7 @@
     "imageType": 60,
     "manufacturerCode": 4216,
     "sha512": "1f12058f8c138d8858a48cec80493f59689c51d1f7f3bc1ea01d29c8723de135e8e9e6b6ab9e537c1db8ed35bfcc5430af97916acf33f57eaf560ccccb8ecf2e",
-    "otaHeaderString": "EBL ZigBeeHabiTemperatureSensor\u0000",
+    "otaHeaderString": "EBL ZigBeeHabiTemperatureSensor",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/d4213f30-3457-4b53-b68a-7fd929ff650a/PS600_20200508.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5889,7 +5889,7 @@
     "imageType": 71,
     "manufacturerCode": 4216,
     "sha512": "e52ee1d3800c0a93c10420545fa1e3cde5ecd01e027642671de06b40953f115dfcc1e61b23f78cbd7d712dfb872781e018a0a2b328b1950b8b34018cdbe22b25",
-    "otaHeaderString": "EBL WaterBugSensor\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL WaterBugSensor",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/bcf0af73-83ef-4140-99ab-b382c6464b50/SS901ZB_20180918.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5903,7 +5903,7 @@
     "imageType": 77,
     "manufacturerCode": 4216,
     "sha512": "97130e20edc3d8f3db63c07a2562b9318422733f6399500b6fcf3d01b6dedb4c80444a05ab50fb0511a351d9b720ec67df1bbe2c6448d19ead3205eddad43db9",
-    "otaHeaderString": "EBL SmartRelay_US\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL SmartRelay_US",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/0ed65137-2c58-4ebb-970c-df456d697cb3/SC824ZB_20190619.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5917,7 +5917,7 @@
     "imageType": 59,
     "manufacturerCode": 4216,
     "sha512": "3d2cbc54ecbae7e9eafdd2d74a0f1b58f0bdcb0252461c26c83ad1c053587afd234d55497a2c6122f182f33f90929397977813ddd4b80465f135287ed5bbcb1b",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://ec2-18-194-20-66.eu-central-1.compute.amazonaws.com/firmware/UG-SYS/ST100/2023-1121/ST100ZB_00310012.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5931,7 +5931,7 @@
     "imageType": 67,
     "manufacturerCode": 4216,
     "sha512": "1330a948f53a81e239796b75dfb29df1f7cfcfcde7bf6b0639275d837ce95d0a876c1eb1fb9e276cd190c52029064459ab23dd518f5c84b9bdecec3d238ffbfc",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://ec2-18-194-20-66.eu-central-1.compute.amazonaws.com/debug/OTA_Test/SAU62X1/SC102ZB_00310023.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5945,7 +5945,7 @@
     "imageType": 68,
     "manufacturerCode": 4216,
     "sha512": "4f32a467f8b4199020e2300e68bb5f6d3463c66571128b0f2df03abb1227dbe1f9c63080fad998cc0bef488864962b16a1e990499b1160d6b5d7a227516a32cf",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://ec2-18-194-20-66.eu-central-1.compute.amazonaws.com/debug/OTA_Test/SAU62X1/ST103ZB_0031001C.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5959,7 +5959,7 @@
     "imageType": 46,
     "manufacturerCode": 4216,
     "sha512": "8d9a2449b4cd5dd8412fe3b4c7cf14371a1fddd51d95e8f971c5bb97a55b3ae4b2f06f4d9d987dcc23d75b18cb73ddff284931657a8b1de73fa622ac6f2c3bd8",
-    "otaHeaderString": "image build\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "image build",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/16b82cfc-b764-4e56-a869-857ae5036478/SB600_20170209.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -5973,7 +5973,7 @@
     "imageType": 65,
     "manufacturerCode": 4216,
     "sha512": "f18234eb5ed1875f50d682791cfb9a58648ba6624db3497930482aa6f8cb670bf77aff7c1794d8f1051574790e517cedbe95a586505dbd14931ad6bd80987dc3",
-    "otaHeaderString": "SAU2BW1_18012801 ota image file\u0000",
+    "otaHeaderString": "SAU2BW1_18012801 ota image file",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/93151e6f-a739-4b47-b0e6-bfef7b4c0ad2/SC904ZB_18012801.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6001,7 +6001,7 @@
     "imageType": 58,
     "manufacturerCode": 4216,
     "sha512": "033f0137aedc765cad80ada61364801d7fad9f40ed4ca5855dddf5a471609e69bd100d3b8ec46fd38ff864313e829dce69cc57b8acaa663affc9258873a197cb",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/38abc21e-f0dd-4aee-8659-cc5c35595711/HTRP-RF(50)_00370009.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6015,7 +6015,7 @@
     "imageType": 64,
     "manufacturerCode": 4216,
     "sha512": "1c9730e93b9eaf0ed382abe0ee5dd08135e9df0179142b00f76ac7eb11556802b2aa7314daa5807a1b842756f4aefdb89596b896ab8519670d05d9464530e468",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/68914d00-d860-474a-8d28-97b8f7f4a665/NTVS41_001F0019.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6029,7 +6029,7 @@
     "imageType": 95,
     "manufacturerCode": 4216,
     "sha512": "68e8a74f6fb9ce8d26ab0e598966e13054b786d013fb301f4018907d6263424bb1b1cc03970c50ae85f129485703746c68cf0825ab044122329e6b58b3359fdb",
-    "otaHeaderString": "EBL DialThermostat\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL DialThermostat",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/f021e8a8-06f0-4a4f-8b13-bd39adcc80e3/AJSQ605RF_00000017.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6043,7 +6043,7 @@
     "imageType": 78,
     "manufacturerCode": 4216,
     "sha512": "ab589119b72cc450cad75be72ba2457273c5d60a28b0a0a6a3d699e2b4b650d22ee94bded49176f9b57bb75e3388feb5d3d9834a2978150fbcc1185430027ccb",
-    "otaHeaderString": "EBL SQT\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL SQT",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/bb3683be-6c01-49fb-91fe-beadc65561fc/SQ610RF_00000026.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6057,7 +6057,7 @@
     "imageType": 79,
     "manufacturerCode": 4216,
     "sha512": "0996fc7f14ecc4b5b3455fb30a1b5ba853f08f32a8c9963a9bd1578349150ff16c528b349870cc0003cf04cf174351977c48f5a78298837214368a822fa99b11",
-    "otaHeaderString": "SQ610\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "SQ610",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/9e996b03-ef2d-423b-b420-0ce9531876c1/SQ610_00000023.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6071,7 +6071,7 @@
     "imageType": 5,
     "manufacturerCode": 4216,
     "sha512": "242ba2399de1be3f200cc9408cc6d1e94eb3b3928fea1687354bb5873897c3b077dabacca624e588436e9e50cc9ee34811be3749a3fa6142341a1dedc84ec986",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/125434a7-b9ad-454d-ae82-5832f2ad0f71/ST880ZB_305C004E.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6085,7 +6085,7 @@
     "imageType": 31,
     "manufacturerCode": 4216,
     "sha512": "4123beb0d9b83f79636168bf153a247a30f013fba1bb8339de937702af81440435f79e182d71fad0316b41df02e2e5517e92f43182c4c18a3f05c46302d53519",
-    "otaHeaderString": "Salus Smart Plug OTA File\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Salus Smart Plug OTA File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/8315dcc4-0cd8-49b6-bee2-cf0537776b6a/SX885ZB_21030500.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6099,7 +6099,7 @@
     "imageType": 66,
     "manufacturerCode": 4216,
     "sha512": "d5c12f065dc55ea3c63ed4230e03f62a9443539d2814115715ffbc2d214d937e8b977a3540900e2fa50cb55d5686de4e7f68f9aee55faeadb943ebd0f3047278",
-    "otaHeaderString": "OTA Image File\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "OTA Image File",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/3261c5ca-9817-42d2-a30b-a52e6c3a87cf/AVA10M30RF_00910040.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6113,7 +6113,7 @@
     "imageType": 63,
     "manufacturerCode": 4216,
     "sha512": "64a5fc3fe95770ca5c8a947a9a19665389374296a055671cdd9fcf1ac98d5f25cc287fc6196c16e1c7fdf69771c67f01bb6bb1d8baf34e05e41667a723906e19",
-    "otaHeaderString": "EBL WindowSensor\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL WindowSensor",
     "originalUrl": "http://ec2-18-194-20-66.eu-central-1.compute.amazonaws.com/firmware/UG-SYS/SW600/2024-0103/NTSW600_20240103.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6127,7 +6127,7 @@
     "imageType": 132,
     "manufacturerCode": 4216,
     "sha512": "3d3f023faf6408cf1cab1f3ca6ffceadd590e0bc8447563362de5167346ce00c9c839866290685e4184c854ffce55490fe9431fea199ef8c224d3d1847eb3fda",
-    "otaHeaderString": "EBL SAL6DIA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL SAL6DIA",
     "originalUrl": "http://ec2-18-194-20-66.eu-central-1.compute.amazonaws.com/firmware/UG-SYS/WC/NH/2023-0527/it600WCNH_00090005.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6141,7 +6141,7 @@
     "imageType": 43,
     "manufacturerCode": 4216,
     "sha512": "9e3150426fbe269325e0f69be3f85825e36f2eceed7e7208c8cdf834e91c400e6e2d7265a27400d64f94c169be6c5822d4666ff88737e2420f4a0b961a1d7807",
-    "otaHeaderString": "Encrypted EBL sau2aw1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Encrypted EBL sau2aw1",
     "originalUrl": "http://eu.salusconnect.io/download/firmware/d4c48f8b-4165-4691-ac2e-3c7ade8b776d/SC906ZB_19121102.tar.gz",
     "manufacturerName": [
       "SalusControls"
@@ -6155,7 +6155,7 @@
     "imageType": 1017,
     "manufacturerCode": 4448,
     "sha512": "4bbcd1c236161a3bb2f50eaa633205087dbbc6ff28e3136a8280e7822e4cd3662b4fd072e08ad2f245da59cd2fef2a52ff3cbefdbc3bf80bfc5b7cfabbcbc26b",
-    "otaHeaderString": "EBL E11_U2E_1017\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL E11_U2E_1017"
   },
   {
     "fileName": "1586412538195_RDS2017007_E11-N1EA_V0.0.71_20200311_release.ota",
@@ -6165,7 +6165,7 @@
     "imageType": 1004,
     "manufacturerCode": 4448,
     "sha512": "c60da6dd092997e06ea81d543ad5097fa4b65e00f1ee4f9faf9c7fec36c10b1e144a0a039f4ed291c31fd4e7437041faff0bcc61cb8b9d13a22c465aa8d813fa",
-    "otaHeaderString": "EBL rgb_lamp\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL rgb_lamp"
   },
   {
     "fileName": "1594189489604_RDS2017039_E12_N1E_V0.0.30_20200630_SVN396.ota",
@@ -6175,7 +6175,7 @@
     "imageType": 1016,
     "manufacturerCode": 4448,
     "sha512": "deca704c355a895b9d4c4b292e581866d7d0198ce2ecb63922465312e2a0062d9ca7596555d8becb6d7cc23f2be72b0081ce74437f6c6f6bdc608b439c6b0362",
-    "otaHeaderString": "EBL E12_N1E_1016\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL E12_N1E_1016"
   },
   {
     "fileName": "1594881275531_RDSE2020003C0511_E1G-G8E_05m_10m_V0.0.14_20200711_release.ota",
@@ -6185,7 +6185,7 @@
     "imageType": 5,
     "manufacturerCode": 4448,
     "sha512": "2942ab766c6542094a9564f2f8565f602b0440fa28b83b8f98addc8f69d8f99a97a08ea6381b69cc3ffd0a62add6feed1266742f0ea5e35bc87cfa425140a20e",
-    "otaHeaderString": "EBL RGB_LampTape\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGB_LampTape"
   },
   {
     "fileName": "RDL2016091_1_E11-G13_V0.0.9_20170921_release.ota",
@@ -6195,7 +6195,7 @@
     "imageType": 3,
     "manufacturerCode": 4448,
     "sha512": "a925acbe2bd50f597a04ceda2810a60e651a1c2ac0369f5d1aadca89c15d6de763c679f7b6549a8001b03d3e9ac9319aca3983911e8f5a81b36420eac070660f",
-    "otaHeaderString": "EBL ElementClassic_E11GX3\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL ElementClassic_E11GX3"
   },
   {
     "fileName": "RDS2014011_Z01-A19_V0.0.46_20171028_release.ota",
@@ -6205,7 +6205,7 @@
     "imageType": 1,
     "manufacturerCode": 4448,
     "sha512": "656319d7933e0bcef63a76698d42c5067844503788fd68443149965e03ecd6cce7ad4c08fddadaafff489b0b4d183738feeba3aff8633030d8501ac60c750937",
-    "otaHeaderString": "EBL Z01_A19_HV2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL Z01_A19_HV2"
   },
   {
     "fileName": "RDS2017028_E1C-NB6_V0.0.22_20180314.ota",
@@ -6215,7 +6215,7 @@
     "imageType": 2100,
     "manufacturerCode": 4448,
     "sha512": "6a55736c9e858898bef68ad794c77290698227a3eb0db325f9cd750ae7a801ccd7780fd8282a60a7a40478c324e4e7c9b83e4b67cd85032926d80daaba93c1eb",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "s40zbLite_v1.0.3.ota",
@@ -6225,7 +6225,7 @@
     "imageType": 65,
     "manufacturerCode": 4742,
     "sha512": "38bc090584b844a0fe75900d6c0efb34a57d776b8d549fa3938cda437de4a454885f557a43ba51c7fa524f79de279a17c9da1d6c656c351f82b6eb46db1cf2b7",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "snzb-05p_v1.0.2.ota",
@@ -6235,7 +6235,7 @@
     "imageType": 2059,
     "manufacturerCode": 4742,
     "sha512": "bb64ae86d9ac2dc398d4520f97554515990ecef5568eebdaa7cdb2be19fe2471b35f53583adc8d8e9e70189a90add27556581bca444690155972ffa6b341b81e",
-    "otaHeaderString": "ota-file-test\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "ota-file-test"
   },
   {
     "fileName": "snzb-06p_v1.0.6.ota",
@@ -6245,7 +6245,7 @@
     "imageType": 2060,
     "manufacturerCode": 4742,
     "sha512": "e722a7058439abba22f2d392f9308c0eb22dcb89ad32c3409983b74a28724713e9709cd2b6b61622dac57487227d2f902dd38291b9116a87b9fc52981669cf46",
-    "otaHeaderString": "vers: ZigBee:00001006\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "vers: ZigBee:00001006"
   },
   {
     "fileName": "zbmicro_v1.0.5.ota",
@@ -6255,7 +6255,7 @@
     "imageType": 7,
     "manufacturerCode": 4742,
     "sha512": "dd1d67ba721740c3eec4da80a2396c6fa09b981bcf2ed9fc712790e45ec9fb392d58d33e36a1bc19899a77a3421a206c1c9c2f7512ed3c8c571e1344f7d996d8",
-    "otaHeaderString": "ota-file-test\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "ota-file-test"
   },
   {
     "fileName": "zbmini-l_v1.1.1.ota",
@@ -6265,7 +6265,7 @@
     "imageType": 1,
     "manufacturerCode": 4742,
     "sha512": "b136d2656ea1197ae84f5e9c2244a9d9697bccab2c448324d9176bac791aff0161afc73c8a1574bbd51c0ea2e318840ca58a0a99da32669d3e5fc776bdf3473a",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "zbminil2_v1.0.14.ota",
@@ -6275,7 +6275,7 @@
     "imageType": 4,
     "manufacturerCode": 4742,
     "sha512": "c80d29e84e3019a84f7a3bdb3e84a3b462e2516c7de5120cdbb68a0e474fcb8b1c5d8eb79b204ad2d9c5af2bed4e544588b192b7884d493a11f82d4ac8625177",
-    "otaHeaderString": "ota-file-test\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "ota-file-test"
   },
   {
     "fileName": "zbminir2_v1.0.4.ota",
@@ -6285,7 +6285,7 @@
     "imageType": 8,
     "manufacturerCode": 4742,
     "sha512": "66b781d8aa2bf5f6cdae2679382bce99b73887f1588008c7d43b9a4ff5ba284463206354b4b8dc01b0a916887c05619350b73ae68c4d1db7a1c76afc1d9975f3",
-    "otaHeaderString": "ota-file-test\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "ota-file-test"
   },
   {
     "fileName": "zbswv_v1.0.4.ota",
@@ -6295,7 +6295,7 @@
     "imageType": 8202,
     "manufacturerCode": 4742,
     "sha512": "49ef75a2d1dd6f706d2182d6cd88c6d98c0aa1e70fdb37e739e6e970266884579794faab361f976aed84c6f9c3c547f7d32f28940f16b72e3f7e454bd5001b1b",
-    "otaHeaderString": "ota-file-test\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "ota-file-test"
   },
   {
     "fileName": "wb_msw3_0_061.ota",
@@ -6305,7 +6305,7 @@
     "imageType": 1,
     "manufacturerCode": 26214,
     "sha512": "9cca5fd3f7b910f26cb2fb8c65bd6b62fc421fdcbb1579ed246a93b876337e8e356ed47724e0a023582d51da85dde38a8a991b64f0051dadd81607c9ff696672",
-    "otaHeaderString": "EBL zb_wb_msw\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL zb_wb_msw"
   },
   {
     "fileName": "wb_msw3_A_061.ota",
@@ -6315,7 +6315,7 @@
     "imageType": 2,
     "manufacturerCode": 26214,
     "sha512": "a6d952c38effabb14419080d2989b218e41b1eff337967708bfe1f1a62054c8c465f9e6dca945e90c46bc7b8185d122a08a504619934619dbaedaccb9bbd4be9",
-    "otaHeaderString": "EBL zb_wb_msw\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL zb_wb_msw"
   },
   {
     "fileName": "zb_wb_msw4_mg21_065.ota",
@@ -6325,7 +6325,7 @@
     "imageType": 15,
     "manufacturerCode": 26214,
     "sha512": "4701a4296faa914e00a4211f14cdac4bde01a1ba8708049a3ce393471ef33a22a1abb7015b9cb6a5ffa5b7e77879e938d0133445476478af40fdc45ea80c1c3a",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "zb_wb_msw4_mgm21_065.ota",
@@ -6335,7 +6335,7 @@
     "imageType": 13,
     "manufacturerCode": 26214,
     "sha512": "ff1df29fbfcf62cbce4608243600598fcf1066ed573efcf1d40a1717a0c06ea1e0d59f606e3d03429ef769776f29f6f01111c662561fe51fae2f9b4844d88cc7",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "1141-0208-01143001-ZMHOC401N.zigbee",
@@ -6345,7 +6345,7 @@
     "imageType": 520,
     "manufacturerCode": 4417,
     "sha512": "3976e5a67ec50a54d05dc2b5ed69f94fe1bd989663e8855511cacf00c4472cf904a2f51d63909374258fc7a2943e6b412a3c47cd5cb7282690c7a5c4d7c24828",
-    "otaHeaderString": "Telink OTA BLE device\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA BLE device"
   },
   {
     "fileName": "1141-0208-01233001-ZMHOC401N.zigbee",
@@ -6355,7 +6355,7 @@
     "imageType": 520,
     "manufacturerCode": 4417,
     "sha512": "4db812502a8043c85eaa86f53dfc0a8857dd5cde23e5f55dd84bf4a6072f5b37f9de6a0cf4fca4b1b0c74ae91e5d9d92f3a7edcd6c21dde6923d81d2e7d56f3e",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "MHO-C401N"
   },
   {
@@ -6366,7 +6366,7 @@
     "imageType": 54179,
     "manufacturerCode": 4417,
     "sha512": "0d2b6be4f0e8b0efdc2f581aee73055a4b3f05a26888e2c3fd0527f81a2f01af445001a91935f2c95ecbda9f83254ef80a9a51c18e592ac9ed00daedb686cbc8",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "manufacturerName": [
       "_TZ3210_ngqk6jia"
     ]
@@ -6379,7 +6379,7 @@
     "imageType": 54179,
     "manufacturerCode": 4417,
     "sha512": "6a0861ee46e659b2b4167aa66b958064b57dbbf25c1dc0dcd848b455f012db5f6d0eb2f9099c3905c9cbfcb0ea75eacb12493a1d31e8fcbb896903a31d5cb646",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "manufacturerName": [
       "_TZ3000_cjrngdr3"
     ]
@@ -6392,7 +6392,7 @@
     "imageType": 54179,
     "manufacturerCode": 4417,
     "sha512": "c541878e792620ad16cc70967e0458c03de21876ad8ed3c3b1eb90c8ecf7bcdfe6bfe711460a5888bb033def141e7dd22d78fe24c44a4e0b9707afb473a2d2a2",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "manufacturerName": [
       "_TZ3000_w0qqde0g",
       "_TZ3000_dksbtrzs",
@@ -6407,7 +6407,7 @@
     "imageType": 0,
     "manufacturerCode": 4648,
     "sha512": "71d600af15976934d28ae0be550a3641967c6b54045f110071ddcf69729e7586c490b723e92eac2825156c07a3126244189af2dd45d5d60a565cd2aa23ad3a4d",
-    "otaHeaderString": "TERNCY-SD01\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "TERNCY-SD01"
   },
   {
     "fileName": "Button_PROD_OTA_V35_v1.00.35.ota",
@@ -6417,7 +6417,7 @@
     "imageType": 54184,
     "manufacturerCode": 4659,
     "sha512": "431aa68788f8e4150ed7b80f0655e234ab34e06afa1b94dce287625991845496d6191578bf335ef56a0c13853616e7ce6feb00b3a2604d60d11384d7dc69f28a",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://tr-zha.s3.amazonaws.com/z2m_firmware/Button_PROD_OTA_V35_v1.00.35.ota"
   },
   {
@@ -6428,7 +6428,7 @@
     "imageType": 54178,
     "manufacturerCode": 4659,
     "sha512": "ef7dd6575b60532af41b63957ccfe750fd8ab188d3c896d2c005bdb19b0c0df2ddf3d68100bf887449ad9085cca410c1bfc446c2aa632ee13d5bb2fb62761440",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://tr-zha.s3.amazonaws.com/z2m_firmware/Door_Sensor_PROD_OTA_V63_v1.00.63.ota"
   },
   {
@@ -6439,7 +6439,7 @@
     "imageType": 0,
     "manufacturerCode": 4877,
     "sha512": "ada3886bc02da299648240f71c6d44950937cb6ab29a9bc115a255eeda0d4b3cf061772a60f186361f4c9afddbf90882a28f83370478a561b31eeebf9180e4f2",
-    "otaHeaderString": "test\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "test",
     "originalUrl": "https://tr-zha.s3.amazonaws.com/z2m_firmware/FW_ha_v1.00.82.ota"
   },
   {
@@ -6450,7 +6450,7 @@
     "imageType": 54177,
     "manufacturerCode": 4659,
     "sha512": "e6baeb11feef7c8d0fb2e47bee2c2fd79b155af2a0d68e445b3dd6d55a9dde15fa81517c11f72190d691e20eb0ec4f090235f7697f9e2aebd7a73a5d8ba88803",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://tr-zha.s3.amazonaws.com/z2m_firmware/Motion_Sensor_PROD_OTA_V79_v1.00.79.ota"
   },
   {
@@ -6461,7 +6461,7 @@
     "imageType": 54183,
     "manufacturerCode": 4659,
     "sha512": "4e071cbdb4e440d37c820ecb844571e6acd0d7c6d3f9c06cbb22dde2f0d2387d5cee0f67ed294333ba5c6b31addd2d1772a3cc2aaf0de582b28fefe3ca42ff8b",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://tr-zha.s3.amazonaws.com/z2m_firmware/SmartCurtain_PROD_OTA_V76_v1.00.76.ota"
   },
   {
@@ -6472,7 +6472,7 @@
     "imageType": 54182,
     "manufacturerCode": 4659,
     "sha512": "99c840f67606ddbdb872768e1ec015b023904d40b0de574d63cae165a76b73fa01d56f01d0e3d43a123a404c2deb713914556c86ada709e2b2a14c061a2c8b2c",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "SmartSwitchGen3_PROD_OTA_V30_v1.00.30.ota",
@@ -6482,7 +6482,7 @@
     "imageType": 54181,
     "manufacturerCode": 4659,
     "sha512": "02dbf23109067616e3bd2cc8b1efc820c4fcf48d56cc3ecb34117d1519d935a886845db73a7d59b56c65cb0a6e4b43c352311f2af24c8c1ddf15164baa438132",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "Soil_Moisture_Sensor_PROD_OTA_V31_v1.00.31.ota",
@@ -6492,7 +6492,7 @@
     "imageType": 54191,
     "manufacturerCode": 5127,
     "sha512": "18aa9d1118fc0a1bf39a037036c9f6229a789a4c4e20f8403838ede9aa771ccfacbf0eff8ca1b52b265f564a4f555613264556f9e1a1884a6f1fd932dc4e4478",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "TRTL_ThermalSensor_PROD_OTA_V37_v1.00.37.ota",
@@ -6502,7 +6502,7 @@
     "imageType": 54185,
     "manufacturerCode": 4659,
     "sha512": "b78cc4b15a1fb1ebedc04143bd9001265df6f380953cec30d50bdd6ed2da062fb260e3a981f1dc8cee0536076c656c033b31327dfc27702c9735fa3f1496bb81",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://tr-zha.s3.amazonaws.com/z2m_firmware/TRTL_ThermalSensor_PROD_OTA_V37_v1.00.37.ota"
   },
   {
@@ -6513,7 +6513,7 @@
     "imageType": 54185,
     "manufacturerCode": 5127,
     "sha512": "3d450453147e414e9998cb000183a22ac6fca656a1a3e11e37b31d7c4fa1ec3f301b28d0b144301630ec33aa1f81afda56d6abfb4191f78d04cd7b9ba27b87b7",
-    "otaHeaderString": "temp_humi_sensor\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "temp_humi_sensor",
     "originalUrl": "https://tr-zha.s3.amazonaws.com/z2m_firmware/ThermalLiteSensor_PROD_OTA_V29_1.00.29.ota"
   },
   {
@@ -6524,7 +6524,7 @@
     "imageType": 54179,
     "manufacturerCode": 4659,
     "sha512": "daba6b3ad69bb070aa46ddae95bf8fa4a3eed151063b9e14f07a5f8937baac5edc922f99b0f6207b9ece62ee65a4ba896721383947c552f94a82c89d4bd04f1d",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://tr-zha.s3.amazonaws.com/z2m_firmware/Water_Leak_Sensor_PROD_OTA_V66_v1.00.66.ota"
   },
   {
@@ -6535,7 +6535,7 @@
     "imageType": 5634,
     "manufacturerCode": 4098,
     "sha512": "1113486a67403d922fc4a462b7477e0a0986fa8862a89b74ab8c5eac7b4ecb31c30f1da9ae1bbc1d6d50ae1fed66d38c37a1834ab71fd384c0555002783aba13",
-    "otaHeaderString": "EBL sdk_route\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL sdk_route",
     "manufacturerName": [
       "_TZE200_kds0pmmv",
       "_TZE200_ckud7u2l",
@@ -6552,7 +6552,7 @@
     "imageType": 55,
     "manufacturerCode": 4190,
     "sha512": "18b1d8028a3de3cf5c28fb442779daa74d5d13bb1f782021db03b945bd02aaa85cf20de17cd23f3d9fbf73224c68a68caa2ad3527ce20913844668161f653c70",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://images.tuyaeu.com/smart/firmware/upgrade/ay1557480848074dO17I/1622438235e5764b7a861.zigbee"
   },
   {
@@ -6563,7 +6563,7 @@
     "imageType": 54179,
     "manufacturerCode": 4417,
     "sha512": "01939ca4fc790432d2c233e19b2440c1e0248d2ce85c9299e0b88928cb2341de675350ac7b78187a25f06a2768f93db0a17c4ba950b60c82c072e0c0833cfcfb",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://images.tuyaeu.com/smart/firmware/upgrade/20220907/1662545193-oem_zg_tl8258_plug_OTA_3.0.0.bin",
     "modelId": "TS011F"
   },
@@ -6575,7 +6575,7 @@
     "imageType": 5634,
     "manufacturerCode": 4098,
     "sha512": "41ebf9932d11708b81144232b2c3fccc7a58d76116be63785b978b91afb1180e32d8ba4f4c8f2f0960637f1662ec9ac28aa42b74e5ab57574000889671d2b8b9",
-    "otaHeaderString": "EBL sdk_route\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL sdk_route",
     "manufacturerName": [
       "_TZ3000_1dd0d5yi"
     ]
@@ -6588,7 +6588,7 @@
     "imageType": 53,
     "manufacturerCode": 4190,
     "sha512": "15188628b13c26b577aa4a9f82a4a411debc7125e19cb13d3d1612095c87c51b9f186e01b33a0f798c3a6875dc68c9f36a614372fe6523cda8e47b045a1a76ba",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://images.tuyaeu.com/smart/firmware/upgrade/ay1557480848074dO17I/16781822109542aac900a.zigbee"
   },
   {
@@ -6599,7 +6599,7 @@
     "imageType": 54,
     "manufacturerCode": 4190,
     "sha512": "50abcc9a6f6351a9bf45994c09b6681cfb255ce617ec299539a937b70fac16110824600269062c5a086b9749a29caf4efe5b3d694e91b04b099efa84b6ba356c",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://images.tuyaeu.com/smart/firmware/upgrade/ay1557480848074dO17I/1678411825b98a1530a8c.zigbee"
   },
   {
@@ -6610,7 +6610,7 @@
     "imageType": 79,
     "manufacturerCode": 4190,
     "sha512": "4b373c33ca742bdb85d9bd7665545be34e4e9660c94218f02c3754f2c9eb4129a428e51b4fe7ccab29f3ee53537b9301cc43b1dbf4c12dae4377025a23848eb8",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://images.tuyaeu.com/smart/firmware/upgrade/ay1557480848074dO17I/16819629247ee0445a5f4.zigbee"
   },
   {
@@ -6621,7 +6621,7 @@
     "imageType": 62,
     "manufacturerCode": 4190,
     "sha512": "95e5c61e2a683a901bc320f5af59330ed6b753808a3efffb8bb8a457c5360fd16403accb4e7f2736b418d3a5ad195df967d72a13ac5d4ffd1951abd05e1844e0",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://images.tuyaeu.com/smart/firmware/upgrade/ay1557480848074dO17I/16844823767736d4b2cbc.ota"
   },
   {
@@ -6632,7 +6632,7 @@
     "imageType": 13,
     "manufacturerCode": 4190,
     "sha512": "befd51ad8ebb145b7d41b5709ace1a6dfe2af9174c161bb7057db570698cd166f10807b9a418440051c03f53c09f41a1d19219be8d0bb95abee7068edc795773",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://images.tuyaeu.com/smart/firmware/upgrade/ay1557480848074dO17I/16855062966c6d846535c.zigbee"
   },
   {
@@ -6643,7 +6643,7 @@
     "imageType": 44,
     "manufacturerCode": 4098,
     "sha512": "a663c437d505b34b08c6a049c999ea6af4ed99db9192f0f7ec8b284644d518f6dafbb889e648bc216581e1a05a918811594fdcc4af66ab1c1178205c895038c7",
-    "otaHeaderString": "EBL Zigbee_Dimmer_1_Gang\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL Zigbee_Dimmer_1_Gang"
   },
   {
     "fileName": "ZPS_CS5490_039.ota",
@@ -6653,7 +6653,7 @@
     "imageType": 24256,
     "manufacturerCode": 4098,
     "sha512": "69f0bd7ecf971546743b5422265a1713741df87a6c0344831ee09b938b751c948bf2251f2c76c0dff09d048b3ce785c3d7f07295afde9acb02255263d275322f",
-    "otaHeaderString": "peanut Power Plug\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "peanut Power Plug"
   },
   {
     "fileName": "home_control_as_hc_slm_1_00.02.zigbee",
@@ -6663,7 +6663,7 @@
     "imageType": 0,
     "manufacturerCode": 4098,
     "sha512": "17357f99b497d42ea28e6c0ec994fea250cbcd27c833e730876efdbef4f2764fb796500cc3ee532135f067634ae94c0b2bb6da59871a6c3a612fec668e350a2d",
-    "otaHeaderString": "EBL HomeControl_DoorLock\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL HomeControl_DoorLock",
     "modelId": "HC-SLM-1"
   },
   {
@@ -6674,7 +6674,7 @@
     "imageType": 321,
     "manufacturerCode": 123,
     "sha512": "b27714b307f6e6ac8fb1c3dacf3ebda25afd7c36fe7cea72637aedd90c1164807035d51e00743069ef4bd165787feab4ce3c678808dddf109e5e76847b695843",
-    "otaHeaderString": "\ngood_image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "\ngood_image",
     "modelId": "PEHPL0X"
   },
   {
@@ -6685,7 +6685,7 @@
     "imageType": 321,
     "manufacturerCode": 123,
     "sha512": "254e4cbc885512a4dc03bd0c9d9d0a2f080c8f8a78dbf2b1e18872a7edfa6474fcefaf6a52f8fa78eec807e5b6c53c229825fdb4c714800bccabc9fe25c8f465",
-    "otaHeaderString": "\ngood_image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "\ngood_image"
   },
   {
     "fileName": "10F2-7B01-0000-0006-0192020D-spo-fmd.ota1.zigbee",
@@ -6695,7 +6695,7 @@
     "imageType": 31489,
     "manufacturerCode": 4338,
     "sha512": "0dee3908a98d434c56d624cee7c49e46315a7571b355b656454c5ad69a38f43ac8b3fce7a3b59b596f91ddb58d151dd6b329753156e8b5acf1d7eb55a50fd659",
-    "otaHeaderString": "ubisys D1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B01-0000-0006-0192020D-spo-fmd.ota1.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -6708,7 +6708,7 @@
     "imageType": 31490,
     "manufacturerCode": 4338,
     "sha512": "20ff31830a17149b353db48afb9ccd356ac75dec04ea0241ef996918471f4b5bc786916caeae79ba75fffbebd6412f06361032a01fd675e85bb931a5fefd7bf3",
-    "otaHeaderString": "ubisys S1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B02-0000-0001-0192020D-spo-fms.ota1.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -6721,7 +6721,7 @@
     "imageType": 31491,
     "manufacturerCode": 4338,
     "sha512": "4bbab66842186f273c8d18d17dda73e6e3c56b519a77b60e994361bd607aad8cb6d1396bb2a63d97327d8e7d850ac38052870fa9f1d4b035db640accae0c7eaa",
-    "otaHeaderString": "ubisys S2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B03-0000-0006-0191020D-spo-fms2.ota1.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -6734,7 +6734,7 @@
     "imageType": 31492,
     "manufacturerCode": 4338,
     "sha512": "d6739de2706120c4be329588933024326db31ee4fae775d60990fe69e934a7a0d51bba000f3091ba1423a40d973494713fef2c598e8813ce07fa6e6fddbf24f1",
-    "otaHeaderString": "ubisys J1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys J1",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B04-0000-0007-0191020D-spo-fmsh.ota1.zigbee",
     "hardwareVersionMax": 7,
     "hardwareVersionMin": 0
@@ -6747,7 +6747,7 @@
     "imageType": 31493,
     "manufacturerCode": 4338,
     "sha512": "05c0e45c29f614ea50e9c9c4752856b35ddff5fdd82dd046cc076ccc1779cd76b39a2fffae9bdedcb1aee378b71d56068f5cbfb7309bb181d33a6ccaf4837dfb",
-    "otaHeaderString": "ubisys S1-R\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1-R",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B05-0000-0004-0191020D-spo-rms.ota1.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -6760,7 +6760,7 @@
     "imageType": 31494,
     "manufacturerCode": 4338,
     "sha512": "eab0f8bbddcd0c7a27ebf65891853a2de218f2243c8e25be57df8db524448c1cafd1b5c4b4585a70811362a7a411968c926a12aece4fa0d2e12ea86d8556b887",
-    "otaHeaderString": "ubisys S2-R\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S2-R",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B06-0000-0004-0191020D-spo-rms2.ota1.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -6773,7 +6773,7 @@
     "imageType": 31495,
     "manufacturerCode": 4338,
     "sha512": "448ccbbbe62ffd097c804dd36e358363aad0d6f66699284c427ec11944e7dd5c355fa03b83f4b0af8bcd16a4f9a5d75b948634a1b57447ebed7d4888d2197266",
-    "otaHeaderString": "ubisys J1-R\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys J1-R",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B07-0000-0004-0191020D-spo-rmsh.ota1.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -6786,7 +6786,7 @@
     "imageType": 31496,
     "manufacturerCode": 4338,
     "sha512": "0fa396f05a629567107a33591c1b76908ca076d6e5db3a04550f2f3f6f9c3ba4ea0f0ba35dea641b10077c22be15b8227427b0b01ef8f57ef0e6bf3c8fc7207d",
-    "otaHeaderString": "ubisys D1-R\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1-R",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B08-0000-0004-0192020D-spo-rmd.ota1.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -6799,7 +6799,7 @@
     "imageType": 31497,
     "manufacturerCode": 4338,
     "sha512": "c56422aa4072d57a159b52edf8b45552b206bf0581e491d27b5c12b1b78137e7e6d0d3b3139c29344626bd1091d6de354d9830efb55e545a7dbd444252629e1b",
-    "otaHeaderString": "ubisys C4\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys C4",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B09-0000-0004-0192020D-spo-fmi4.ota1.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -6812,7 +6812,7 @@
     "imageType": 31498,
     "manufacturerCode": 4338,
     "sha512": "c404999420e0e366e87dbbc9a798937d5df1b3d1a5f97d2fa81f34fb2c244d85e98d32a73f66aecf129c07a13b276bc3af1eac0fc59ad45589885c28eaa2f633",
-    "otaHeaderString": "ubisys R0 1.9.3\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys R0 1.9.3",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B0A-0000-0005-0193020D-m7b-r0.ota1.zigbee",
     "hardwareVersionMax": 5,
     "hardwareVersionMin": 0
@@ -6825,7 +6825,7 @@
     "imageType": 31499,
     "manufacturerCode": 4338,
     "sha512": "4196c923f4751d3d6d9719a0f0f66f344d1b8d1f1df991e47fb796d8b6f07fe1f408605f1e7c78f0df8ae0301c5a09c596ec6cfa0fe22b47e663241c98d67bb5",
-    "otaHeaderString": "ubisys H10\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys H10",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B0B-0000-0001-01900210-m7b-h10.ota1.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -6838,7 +6838,7 @@
     "imageType": 31500,
     "manufacturerCode": 4338,
     "sha512": "1cd9a601a1fb34edeb00b7b76b4de2792bd416826c2522377304de7139c52484449d6af4bd2b4262eee31a479352d0aaeb1c4f646c9155086d50db668e6cdf1c",
-    "otaHeaderString": "ubisys WD1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys WD1",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B0C-0000-0000-01000206-m7b-wd1.ota.zigbee",
     "hardwareVersionMax": 0,
     "hardwareVersionMin": 0
@@ -6851,7 +6851,7 @@
     "imageType": 31501,
     "manufacturerCode": 4338,
     "sha512": "773d51705c7b0666c3322e4a15100b258b8d8a085962e5f49c0bcfe5cd65345c46dd9bf8eb84aad7fbc2647401fb5612ea27549956ec7e31b2f1cdce2de2b6b5",
-    "otaHeaderString": "ubisys H1 1.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys H1 1.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B0D-0000-0001-01500427-m7b-h1.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -6864,7 +6864,7 @@
     "imageType": 31505,
     "manufacturerCode": 4338,
     "sha512": "613ed06ed20a29f762fc0f838c1921914f924e169531fd292c364525486348f362ccbc1757a405cf49b5a78a318ded9bda82419f1b53fbdbaabd60edc07c9de1",
-    "otaHeaderString": "ubisys LD6 0.9.4\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys LD6 0.9.4",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B11-0000-0001-00940240-m7b-q95.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -6877,7 +6877,7 @@
     "imageType": 31521,
     "manufacturerCode": 4338,
     "sha512": "e2dae4e58b792c57bd7b6d79457f4992d6825bc600055f269caaba6db8f1eda407648201f7a3aa25a7b090991aaf725dba0cca4ef0bb06e1cb49eeab94896388",
-    "otaHeaderString": "ubisys D1 1.9.4\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1 1.9.4",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B21-0000-0006-0194020E-spo-fmd.ota.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -6890,7 +6890,7 @@
     "imageType": 31522,
     "manufacturerCode": 4338,
     "sha512": "100b4381b86f8f87bd7af465e5b21598a5d5db96af0184c04dc8ef357b753ebef1b13fe4fb3c4ef497d57d491c9ca9b3b1c65cc433fd422656a5139a1ec5d791",
-    "otaHeaderString": "ubisys S1 1.9.3\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1 1.9.3",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B22-0000-0001-0193020D-spo-fms-rev0-1.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -6903,7 +6903,7 @@
     "imageType": 31523,
     "manufacturerCode": 4338,
     "sha512": "6b59596d69c0049ac8111ddec0edee16c7fe3353900e9d04eef7a3d42a7cda10152883e743b8114b2140957fc417fa64c62b15fc236a4d8d86a10cb786742cf2",
-    "otaHeaderString": "ubisys S2 1.9.2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S2 1.9.2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B23-0000-0006-0192020D-spo-fms2.ota.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -6916,7 +6916,7 @@
     "imageType": 31524,
     "manufacturerCode": 4338,
     "sha512": "cc99d8c41fd80730fcca3cd09b61e352b5dd62e35d666e2b8bee9a449ff85dd0b7820258154ff1d748945a59cd9d3163874a906ef80684058f836a7e4d7abdc6",
-    "otaHeaderString": "ubisys J1 1.9.2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys J1 1.9.2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B24-0000-0007-0192020D-spo-fmsh.ota.zigbee",
     "hardwareVersionMax": 7,
     "hardwareVersionMin": 0
@@ -6929,7 +6929,7 @@
     "imageType": 31525,
     "manufacturerCode": 4338,
     "sha512": "d549288431cc6d66f78df33e8160d2310f375154675f5563291798edda18e1b75480c0160b8aafd24e9c1f8b105d73f2553a771e378d218c0ff3998639170ff0",
-    "otaHeaderString": "ubisys S1-R 1.9.2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1-R 1.9.2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B25-0000-0004-0192020D-spo-rms.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -6942,7 +6942,7 @@
     "imageType": 31526,
     "manufacturerCode": 4338,
     "sha512": "2af49c67b63c7d42450091c3a8d5682f3c3d06f11470b61ffa194b3da67fffc9151f653e0b54c886ee78482313b12e2a7893c0b465e577f541e830c598f6408d",
-    "otaHeaderString": "ubisys S2-R 1.9.2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S2-R 1.9.2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B26-0000-0004-0192020D-spo-rms2.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -6955,7 +6955,7 @@
     "imageType": 31527,
     "manufacturerCode": 4338,
     "sha512": "305edd6055e2b23c0e48751cc4dcf95d436d05fec604903e102e6333b9f930c603d531bb223f65b2d744bd460275283c85338925daf199c706ac0152d8d481ea",
-    "otaHeaderString": "ubisys J1-R 1.9.2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys J1-R 1.9.2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B27-0000-0004-0192020D-spo-rmsh.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -6968,7 +6968,7 @@
     "imageType": 31528,
     "manufacturerCode": 4338,
     "sha512": "bf4afd298edad1a2976b02169c9d84880c11d65b10ff48a55fbb168156f1a2cc0014b6f79dd02fc5d117962b57d0127653f5142f65d9653609c3bc2e54350f68",
-    "otaHeaderString": "ubisys D1-R 1.9.5\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1-R 1.9.5",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B28-0000-0004-0195020E-spo-rmd.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -6981,7 +6981,7 @@
     "imageType": 31529,
     "manufacturerCode": 4338,
     "sha512": "9eff1e73b9d1eb25e6f0f39fad8c15ee505fcca8fb64d737e87bf4c0a4a88c915cc32d0198d5e7893a694b67869cb4365958a9ddff0da957c1a7ceea1849e595",
-    "otaHeaderString": "ubisys C4 1.9.4\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys C4 1.9.4",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B29-0000-0004-01940221-spo-fmi4.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -6994,7 +6994,7 @@
     "imageType": 31530,
     "manufacturerCode": 4338,
     "sha512": "e87af94a95f4d6d8d3eb15c183fee5383bbf6d6a9a1340516e6a95e7ff7d71f06d08227bdaaec140b186e45366e17a6f4fae769266f8531cbfbc4cbea300c029",
-    "otaHeaderString": "ubisys R0 2.0.1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys R0 2.0.1",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B2A-0000-0005-02010230-m7b-r0.ota.zigbee",
     "hardwareVersionMax": 5,
     "hardwareVersionMin": 0
@@ -7007,7 +7007,7 @@
     "imageType": 31531,
     "manufacturerCode": 4338,
     "sha512": "438a8ea59ae39f1d4416bd0a1267ed72657b3966fea4badd1febc248df1dafc85742f6449bc553287e3a905b2ddd268da16680662159d091cdec0a9b05088d3d",
-    "otaHeaderString": "ubisys H10 1.9.2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys H10 1.9.2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B2B-0000-0001-01920210-m7b-h10.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -7020,7 +7020,7 @@
     "imageType": 31532,
     "manufacturerCode": 4338,
     "sha512": "6545ebd2a0a8ce5cdcf39a2146d2ac9f648632c889ba82b2adf2d285c4a83f42ec8ce1abd215466f7d5692738e66d1f9753572b541fd8e4c7f18ede723cbd041",
-    "otaHeaderString": "ubisys LD6 1.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys LD6 1.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B2C-0000-0001-0150044D-ld6.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -7033,7 +7033,7 @@
     "imageType": 31533,
     "manufacturerCode": 4338,
     "sha512": "b348e455e1b608890db1c06c23f911b6ada09f96610586c304c42af00f1c1c70025df532d46983e1fac9ec699bb27d0f74eb57c8a9c6adf6edfee7a2f2100dec",
-    "otaHeaderString": "ubisys H1 1.7.2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys H1 1.7.2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B2D-0000-0001-0172044D-m7b-h1.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -7046,7 +7046,7 @@
     "imageType": 31537,
     "manufacturerCode": 4338,
     "sha512": "9d8be9b4d07a5f46f0183179d552f73bc2d97aeab37dc01007d76783efeb593b3c0bd8945166bb0ebc5468fb9f91907650dbd1bf3f7f5baaa96c0cd078d9a79c",
-    "otaHeaderString": "ubisys D1 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B31-0000-0006-02500447-spo-fmd.ota.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -7059,7 +7059,7 @@
     "imageType": 31538,
     "manufacturerCode": 4338,
     "sha512": "ce65e5c5e1d9ba39092f4696ad2a69795aa55050e58a9075cf57b44ea8347383050ace7a7c02409498108ea87eaf755ce2016a836f45519678381248ff19681e",
-    "otaHeaderString": "ubisys S1 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B32-0000-0001-02500447-spo-fms-rev0-1.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -7072,7 +7072,7 @@
     "imageType": 31539,
     "manufacturerCode": 4338,
     "sha512": "3072cb363ae9861567279d6ed965fb248c30acf0e59193321eae325732ac8aa0b4ab3d5a8a0b4eb60bb13f8a753195ee356505c710f0309a62f00095aff37420",
-    "otaHeaderString": "ubisys S2 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S2 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B33-0000-0006-02500447-spo-fms2.ota.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -7085,7 +7085,7 @@
     "imageType": 31540,
     "manufacturerCode": 4338,
     "sha512": "49d9be6554ae3e0d4fa40bfafa23cf87635c02353d37be5a2a35f0a4c83ad3f342afb29d746bcb3ded7dac5bae4797d289bfecdd2aa496d76aa8049ac4a67aed",
-    "otaHeaderString": "ubisys J1 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys J1 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B34-0000-0007-02500447-spo-fmsh.ota.zigbee",
     "hardwareVersionMax": 7,
     "hardwareVersionMin": 0
@@ -7098,7 +7098,7 @@
     "imageType": 31541,
     "manufacturerCode": 4338,
     "sha512": "bfc44b028618db233045a54827e6a5dba9ff24d6b284d32f33e7e2d71aa1b3a7a1d4cd0f78b8ce004de885f9a596f5448364293633714b542608b13d2bf380ea",
-    "otaHeaderString": "ubisys S1-R 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1-R 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B35-0000-0004-02500447-spo-rms.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -7111,7 +7111,7 @@
     "imageType": 31542,
     "manufacturerCode": 4338,
     "sha512": "8f4a3869a43cfc9e4d35c9640633d0c1b0678e0aca6edbee1e5aa91f714d9d786dd4585627a919a423011b41dc66661cb6cf2beb1d8421bf7c3609cb3409c35f",
-    "otaHeaderString": "ubisys S2-R 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S2-R 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B36-0000-0004-02500447-spo-rms2.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -7124,7 +7124,7 @@
     "imageType": 31543,
     "manufacturerCode": 4338,
     "sha512": "b553db5f1cc27a6830e04b1d4f4fee2fd8c4477d9dbe44404e38ab563b5134b183555f04258306843578262ac75e136fa37f98cc1dea1b1fcebe473df8d886ca",
-    "otaHeaderString": "ubisys J1-R 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys J1-R 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B37-0000-0004-02500447-spo-rmsh.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -7137,7 +7137,7 @@
     "imageType": 31544,
     "manufacturerCode": 4338,
     "sha512": "02ed2e254494a9242b2f132df1e87396cfcddb3fa15fe3f8960a70ccc57417355ff184abf9af13455d07f7b3c91d2afe94ef1ec26961a916d270f5f3c8712bbb",
-    "otaHeaderString": "ubisys D1-R 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1-R 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B38-0000-0004-02500447-spo-rmd.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -7150,7 +7150,7 @@
     "imageType": 31545,
     "manufacturerCode": 4338,
     "sha512": "86c71aa053f61d20ee3a553c012d3c16afea557d2c6e28da8b30019a5633aced20959ad26f48655487682d06d105fdd293283ec37f828e168f596d2123c143ca",
-    "otaHeaderString": "ubisys C4 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys C4 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B39-0000-0004-02500447-spo-fmi4.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -7163,7 +7163,7 @@
     "imageType": 31546,
     "manufacturerCode": 4338,
     "sha512": "aace578a76c957613c25fa47f533af0dadaa7150ad1d62ef019ab081d186bc6fe79cb2f6e008015b7f5aa890ad542b71c8c95beafe78480b76e399aa68783b2f",
-    "otaHeaderString": "ubisys R0 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys R0 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B3A-0000-0005-02500447-m7b-r0.ota.zigbee",
     "hardwareVersionMax": 5,
     "hardwareVersionMin": 0
@@ -7176,7 +7176,7 @@
     "imageType": 31547,
     "manufacturerCode": 4338,
     "sha512": "7aa6186e680f62447d8bb226d1902affe940b3d070ae228d545a172d75d6e9552febef60959762704003af5dcd319dce06acf33f19ce7cc7bdb90e5aad95e601",
-    "otaHeaderString": "ubisys H10 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys H10 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B3B-0000-0001-02500447-m7b-h10.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -7189,7 +7189,7 @@
     "imageType": 31557,
     "manufacturerCode": 4338,
     "sha512": "6fe7a4899d98399804f88951aa069314b9df8a531966b79065027f359ca02b2ed3e7b0ff460f48e6411001acea91618216c67b0c69b4569aea50c47f9175e793",
-    "otaHeaderString": "ubisys S1-R 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1-R 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B45-0100-0100-0250044D-ubisys-s1r-qpg6105.ota.zigbee",
     "hardwareVersionMax": 256,
     "hardwareVersionMin": 256
@@ -7202,7 +7202,7 @@
     "imageType": 31561,
     "manufacturerCode": 4338,
     "sha512": "1f5ac51f84fee69c5a7be2f4d309b9bea81ff01af7f65b0d5819b637ceee251130fcc39b7580c662489afc41caae44b7c8f0522db166d64c9e01b2bb0a20ca55",
-    "otaHeaderString": "ubisys C4 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys C4 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B49-0100-0100-0250044D-ubisys-c4-qpg6105.ota.zigbee",
     "hardwareVersionMax": 256,
     "hardwareVersionMin": 256
@@ -7215,7 +7215,7 @@
     "imageType": 31562,
     "manufacturerCode": 4338,
     "sha512": "1e15d52adaa4cbefa0c1dafe59e119804ce12f234db4ba6ef127f3a3e6a455e8731c79ffdfdc4fb24b3e4a7d7f9d86312407f2ee979e337ade9d682b6e986a8a",
-    "otaHeaderString": "ubisys R0 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys R0 2.5.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B4A-0100-0100-0250044D-ubisys-r0-qpg6105.ota.zigbee",
     "hardwareVersionMax": 256,
     "hardwareVersionMin": 256
@@ -7228,7 +7228,7 @@
     "imageType": 4113,
     "manufacturerCode": 13379,
     "sha512": "ec392dc3cde87ac2a6f39d848f38094f7a8a3a2df4818772ec866fdf9af03bcff3d0ec1985a00874a8b9599aaedc89bc7c26ac4c2b5732dcd7d40f6fff8a3a80",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://github.com/xyzroe/ZigUSB_C6/releases/download/407/ZigUSB_C6.ota",
     "modelId": "ZigUSB_C6",
     "releaseNotes": "https://github.com/xyzroe/ZigUSB_C6/releases/tag/407"
@@ -7241,7 +7241,7 @@
     "imageType": 54187,
     "manufacturerCode": 4659,
     "sha512": "5bd3a87405696100395e93f3f72a512f704c82a1c46775631a4497ffd847d822cb13fdb552213734bac2f46b60027f8939dd793283a2fec60a43e3717afeb502",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0331-191d3685-sp240-1.9.29.ota",
@@ -7251,7 +7251,7 @@
     "imageType": 817,
     "manufacturerCode": 4454,
     "sha512": "041ac46c276770f7179aed8222a52813d50d981776208fa4fa76bf432f0fa73dc8a09aabfe61894aa734f18fdc997a6842aaee7ab6a4d3554914a42e3fcdca00",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0332-191d3685-sp242-1.9.29.ota",
@@ -7261,7 +7261,7 @@
     "imageType": 818,
     "manufacturerCode": 4454,
     "sha512": "d3f1728a8b6e70501b21414cb0bbbd17934a56a64d2249500db36e29821a3b5f0551b42c63abbe837426cf657d25fa497585cf86ba6f41209ce40a56cadb9319",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0333-191d3685-sp244-1.9.29.ota",
@@ -7271,7 +7271,7 @@
     "imageType": 819,
     "manufacturerCode": 4454,
     "sha512": "447f8b22c7c9ed1b2d0d4266c9d20087f62c73a5e1f677388747d6050044512f884266565097a9dcc37893345e5d39cf79b99a63ef036296174c8054f7f372e6",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0334-191e3685-sp240v2-1.9.30.ota",
@@ -7281,7 +7281,7 @@
     "imageType": 820,
     "manufacturerCode": 4454,
     "sha512": "72e94cc57ae49c53e11e98bdd4a24dd08c640e19d3e31b059e1df458aea80b1cc95a8d4edff30ba6b4e173d8d5e70607a833533656e6475bfa51d7c9edb6bc7b",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0335-191e3685-sp242v2-1.9.30.ota",
@@ -7291,7 +7291,7 @@
     "imageType": 821,
     "manufacturerCode": 4454,
     "sha512": "b85050cf4f8352967966df3c65cb550fbaac54b4cd987fc8a0ca176acf42f30b38a0fcfe3b28562d670e630191247d2095b732a2230596feb5c7e8c9599a5044",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0336-191e3685-sp244v2-1.9.30.ota",
@@ -7301,7 +7301,7 @@
     "imageType": 822,
     "manufacturerCode": 4454,
     "sha512": "857d8d4b4b179f92120072d8084d1f2b5b3e20a94fca6cf76ccc6afbbc8ba8f9e091a30144ab35e6edc6984fb45427289aaf8def4838a065b98cf9728716109d",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "Namron_4512750_v32_2025_02_14.ota",
@@ -7321,7 +7321,7 @@
     "imageType": 8199,
     "manufacturerCode": 4742,
     "sha512": "9bb3374caba58ac72d4ffb1f601a4b35ec7ffa74a45bb03ff9892919929399ea4484fafd681f27368646650929dd7a56c6bf230c4d39971658d21b89c382073e",
-    "otaHeaderString": "vers:00001300,00001204\n\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "vers:00001300,00001204\n"
   },
   {
     "fileName": "20240731114104_OTA_lumi.switch.b1nc01_0.0.0_0029_20240729_69827E.ota",
@@ -7353,7 +7353,7 @@
     "imageType": 54194,
     "manufacturerCode": 5127,
     "sha512": "ef965246281a1b3da9f908b8c0d45e597c459b7db1e4b98a0ac1b3f3fab67058216eaf8c31ef5b6d9fd413c0cbb0030b38062581a2daa21c3ef42d09afcf5af8",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "GarageDoorSensor_PROD_OTA_V36_v1.00.36.ota",
@@ -7363,7 +7363,7 @@
     "imageType": 54193,
     "manufacturerCode": 5127,
     "sha512": "b68cbc5385270c5196daaec55e5175d8203006ed16672ed3e860b3a630dc23965994123a27bb3a2248ae2f0d9871c81c8b38259f2d7aca28651758f936515535",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "PMM300Z3_OTA_ENC_V8_ENC.ota",
@@ -7385,7 +7385,7 @@
     "imageType": 297,
     "manufacturerCode": 4107,
     "sha512": "c21b60bca9276fb9c1cecfe4b61b91a4cc90ca9a48cd75c93fb2ed8fc33853e81b0f4e618afbc7ba6538b7a868669765698611c3db2430389aa5fae86c28c5d3",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "mmwave_module_fw_V3_14_3.ota",
@@ -7396,7 +7396,7 @@
     "imageType": 260,
     "manufacturerCode": 4655,
     "sha512": "f89ead312763061ca44dd3cd917c223087877ce235a2ac41ef22b31c43b6566baab267a3d90a649812364a7b4c065757fa4117b64fbed74857bae3d2493cbf27",
-    "otaHeaderString": "LD6002B\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "LD6002B"
   },
   {
     "fileName": "snzb-02d_v2.3.0.ota",
@@ -7406,7 +7406,7 @@
     "imageType": 2053,
     "manufacturerCode": 4742,
     "sha512": "1ff8bc7d3d38adc87b4b2050fc6241efdd989c6410b6a73f6f8dde999450f9468bc08ca62f7223adc61a2d655a746c257002af4c2c36f3c089c182cc4a58aaea",
-    "otaHeaderString": "FWSN_SNZB02D\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "FWSN_SNZB02D"
   },
   {
     "fileName": "10F2-7B02-0002-0007-0192020D-spo-fms.ota1.zigbee",
@@ -7417,7 +7417,7 @@
     "imageType": 31490,
     "manufacturerCode": 4338,
     "sha512": "27743f96962964d3670c7cc1cf90356d1e77b1277d4cc97a501b01e0600768fd9335f2a9b94efc7c8e4ae892eeebc7a5a2c99ab4b223d0d957282ac66e11c7ac",
-    "otaHeaderString": "ubisys S1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1",
     "hardwareVersionMin": 2,
     "hardwareVersionMax": 7
   },
@@ -7430,7 +7430,7 @@
     "imageType": 31522,
     "manufacturerCode": 4338,
     "sha512": "94d2430f2c4ddd9ecbad6199608958715ce48269f352e18636e62bf7f6d7c17b1d9fb444fc9f8b4dea26da265f4cc34d4df27557b97095a30140e0470a9f9c65",
-    "otaHeaderString": "ubisys S1 1.9.3\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1 1.9.3",
     "hardwareVersionMin": 2,
     "hardwareVersionMax": 7
   },
@@ -7443,7 +7443,7 @@
     "imageType": 31538,
     "manufacturerCode": 4338,
     "sha512": "9d3e6e375c865024a29de5760645be70cf1b549442b5f9b97d417bf4a423275076b16eb8a2e9bec91ea364e7e318701069516be71bbc7b629eea1455130c1dac",
-    "otaHeaderString": "ubisys S1 2.5.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1 2.5.0",
     "hardwareVersionMin": 2,
     "hardwareVersionMax": 7
   },
@@ -7455,7 +7455,7 @@
     "imageType": 593,
     "manufacturerCode": 4117,
     "sha512": "900688dea743db3097d59d90e5c4a2a4551232a1b5dd21be43e66d58de24ee0b98838e6b3ff400fb044051c97a48dacda429b75f2a9e1259af5d9121ef1238b1",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "Zigbee_A19_Bulb_OTA_V66_1.00.66.ota",
@@ -7465,7 +7465,7 @@
     "imageType": 54188,
     "manufacturerCode": 5127,
     "sha512": "b89f44cee97a229f7c98404f7828824d7c363724f2fe981dd9c656624fbdb1ad6ed9082735aff1bfcd488868d32a08728fd851405c29904d5264e59ae422097d",
-    "otaHeaderString": "temp_humi_sensor\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "temp_humi_sensor"
   },
   {
     "fileName": "PLUG_EU_EM_T-0x00DC-0x033D3674-MF_DIS.OTA",
@@ -7476,7 +7476,7 @@
     "imageType": 220,
     "manufacturerCode": 4489,
     "sha512": "052726f1832285df5e2383d71f36ab844dc407dc0b3cf064329a0f14031b86341240dc9675dd7ad91c41e1eab84ac854e9b1eff826f2efb3748cd2a36788a5a7",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "releaseNotes": "1.Support real-time power, current, and voltage report.\r\n2.Support total power consumption statistics feature to track energy usage.\r\n3.Support power-on on/off configuration, allowing users to set initial operating state when power-on."
   },
   {
@@ -7488,7 +7488,7 @@
     "imageType": 230,
     "manufacturerCode": 4489,
     "sha512": "24f916a897010ea397173412ac2a255e1e2c4354ea5a54fa0ff0e0af140094656cfc1bb4dce9ea5a7418132fb489438610cd4bc47dc684b61cd0b26d76213891",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "releaseNotes": "1.Support real-time power, current, and voltage report.\r\n2.Support total power consumption statistics feature to track energy usage.\r\n3.Support power-on on/off configuration, allowing users to set initial operating state when power-on."
   },
   {
@@ -7500,7 +7500,7 @@
     "imageType": 8347,
     "manufacturerCode": 4447,
     "sha512": "126bbc9d6d16682ac3d83a71491779d2ea5b653d8eda8c80ef22e1f2e834219cd2fd5151bc463a779714f78657a25fdb7344f950cfc397237d9ebe5c9ec0b553",
-    "otaHeaderString": "\u0014OTA_lumi.motion.ac01\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "\u0014OTA_lumi.motion.ac01",
     "modelId": "lumi.sensor_occupy.agl1",
     "releaseNotes": "Enhance the accuracy of static human recognition, refine the mechanism for distinguishing between human movement and stillness, reduce false alarms by robotic vacuum cleaners, and minimize the likelihood of false alarms triggered by small pets, curtains, and other factors"
   },
@@ -7513,7 +7513,7 @@
     "imageType": 259,
     "manufacturerCode": 4655,
     "sha512": "a6aef13a44da2265d99686c2248631aaaff285881f81e2bf9ffb5048e8c2dcae65f91acfecc98ac83d87fd6f1a6e4cc57fb2cd74b883d76e89e773d3192920bf",
-    "otaHeaderString": "vzm32-sn_mmWave\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "vzm32-sn_mmWave"
   },
   {
     "fileName": "6565-0391-10153001-tuya_thermostat_zrd.zigbee",
@@ -7523,7 +7523,7 @@
     "imageType": 913,
     "manufacturerCode": 25957,
     "sha512": "d3c3c1fd5690d2817d0fb05c283a8b1f511ec60946a5d50ab63fce822054cbdd95fb7099f43cce7e9792ad2b3f0ced96f43dc151882cd71010cd5fe3db40d46d",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "manufacturerName": [
       "Slacky-DIY"
     ]
@@ -7537,7 +7537,7 @@
     "imageType": 272,
     "manufacturerCode": 4655,
     "sha512": "53bee137d4450ca55d1d0cd9e49777daa01729c421b04c750fc25ae01bdf79394c15b9ca3178a08f42895e987a034c4b030866edb83e66cd105e655b8319c35c",
-    "otaHeaderString": "VZM30-SN_OnOff\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "VZM30-SN_OnOff"
   },
   {
     "fileName": "6565-0204-20043001-watermeter_zed.zigbee",
@@ -7547,7 +7547,7 @@
     "imageType": 516,
     "manufacturerCode": 25957,
     "sha512": "37cf00ec6985abcfd7abd0550b2b5f260917cfe06c1e0a8bd4da81bf7e111c5be9a58eb32e4637848ca8aea09458e8067bc9f26c30e95d7c38b99536ca1bfe85",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "manufacturerName": [
       "Slacky-DIY"
     ]
@@ -7560,7 +7560,7 @@
     "imageType": 915,
     "manufacturerCode": 25957,
     "sha512": "a2b8e5d3c35bb397705fbf1d66f956bf54fcb2035fd54c21b45077d192826df94f1c7d8fd5e9ea2d41fddf26242e21f6aeea9aff990a921036ee635b8e997a38",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "manufacturerName": [
       "Slacky-DIY"
     ]
@@ -7584,7 +7584,7 @@
     "imageType": 513,
     "manufacturerCode": 4417,
     "sha512": "375019d234add85c09a3c15beafc633a1e1a89f6e5d2ccd9cedaf850c94393ae2af802452669b2edbc0a5c5bdffb1ca3908b4215bf2c973099c1adc7c91c2cd3",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "MHOC401-z"
   },
   {
@@ -7595,7 +7595,7 @@
     "imageType": 514,
     "manufacturerCode": 4417,
     "sha512": "5572ca8e274af8f7c06bda26622275ec3faa5b77b0924f25f8d1de95ac59e68475ef623cd1b1a863495762f06e816e53231c0d75ffb993b9f7655af05814836a",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "CGG1-z"
   },
   {
@@ -7606,7 +7606,7 @@
     "imageType": 518,
     "manufacturerCode": 4417,
     "sha512": "ed84461b2a442c3b4a7101b8711577487f4b5c9977af280c59541287e397640396f3f54d2630e88d67a658fd4cc08d3f5813f4e4ed9854060d1a2a1c32077662",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "CGDK2-z"
   },
   {
@@ -7617,7 +7617,7 @@
     "imageType": 519,
     "manufacturerCode": 4417,
     "sha512": "f0d433f7a03413d3cb2c99d317b0475bab0c9ae5d9ea70d2dcd4b3501e2f7a25ff96f6f23489956c53a76f886412daee8e38c1143c61d17dcce37ef258572e63",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "CGG1N-z"
   },
   {
@@ -7628,7 +7628,7 @@
     "imageType": 520,
     "manufacturerCode": 4417,
     "sha512": "1d23ae0b67c4a2319d18639dd574069c5945101fd89caa27df2e3ba61c6b5d2e13f94bfddae7e0d1cfc2f2b254a7c24fe228282d992c28f0a933d6ce235e5ac2",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "MHOC401N-z"
   },
   {
@@ -7639,7 +7639,7 @@
     "imageType": 522,
     "manufacturerCode": 4417,
     "sha512": "92c8bf605c3c331b47ed1f0ec599ec85d19f31c4af364c7fbac8898469d12496b4ada36250c9e49e7bb2769e56d96031ae1ac24df2276047cbe5541f0d5cea5f",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "LYWSD03MMC-z"
   },
   {
@@ -7650,7 +7650,7 @@
     "imageType": 523,
     "manufacturerCode": 4417,
     "sha512": "3c28d8b628be47cc6858369f0622e1cd59074f72bbda74c32f056d7948713e67fe8b4f47cc3b0e258b99d6ebdb20f6591dbc795d4be70dc5053dd8ea05128122",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "MHOC122-z"
   },
   {
@@ -7661,7 +7661,7 @@
     "imageType": 529,
     "manufacturerCode": 4417,
     "sha512": "530f35992a957f39fc5b0e0b9daefeffad0fae84a01439811ee5f6039c6675f996cbe1e92bb8db709ddfd6d8edc86b06ca1096f5f80e700052ca7a06b559d02d",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "TS0201-z"
   },
   {
@@ -7672,7 +7672,7 @@
     "imageType": 534,
     "manufacturerCode": 4417,
     "sha512": "34db18706edf51eb0d79c1da8055c558cb84de9d16ce32fdb70bcb21e48cf8b4d821c4853e3bfc895cfb094550b30fab51ace3ee759f4e7d4a033d45097ada6c",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "ZTH03-z"
   },
   {
@@ -7683,7 +7683,7 @@
     "imageType": 539,
     "manufacturerCode": 4417,
     "sha512": "5d5aa071403b4a4664d0771ece7c1d7aa116638cadb6b1291c8c4cb11d56f60577b35ef7899b4af6c8b9e3633aef6f330d5142bf123391700570dbd4440517a6",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "ZTH01-z"
   },
   {
@@ -7694,7 +7694,7 @@
     "imageType": 540,
     "manufacturerCode": 4417,
     "sha512": "9dd31c3b9a334b232f6ef13f05abe1f27983ba7f130833f294f2c17c80a04a7617c18d08d3f2b3a7fb0e334c343a52e44632754141d890dd94782ab9a5063161",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "ZTH02-z"
   },
   {
@@ -7705,7 +7705,7 @@
     "imageType": 542,
     "manufacturerCode": 4417,
     "sha512": "9d617a82a0c4f4a4663ca89256d1f703447ab79aedbc22d8650f3ba2c5dac27c615a3648238d324850e80c01299c2818ba82b4adb57de3bbd379e1f2035627bb",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "TH03-z"
   },
   {
@@ -7716,7 +7716,7 @@
     "imageType": 543,
     "manufacturerCode": 4417,
     "sha512": "a759d225e2a5f915add9c1eaf96d2ef8f63de450276c1085fbe3bb8c41893fe50f7c2c0f302b20fa852c91ae0fa2d411c39788ffb4300c8f7489e79544d96a63",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "LKTMZL02-z"
   },
   {
@@ -7727,7 +7727,7 @@
     "imageType": 545,
     "manufacturerCode": 4417,
     "sha512": "d3c8d568f57490a43f44e174e3ac9b7a6b66a8a8866a73998c40dcafb56347caf3f290741bd49a2eeb1b7a8bb713d57c5b29fb5a2858b70abae034938f215f57",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "ZTH05-z"
   },
   {
@@ -7738,7 +7738,7 @@
     "imageType": 549,
     "manufacturerCode": 4417,
     "sha512": "deee176b5f18202211ae27074cb7fc125f57aa80e7104976eed4f0e70ba261a33bb808a14c90940eb2ff99278d030e6cb239324adb1f92a767a35979eed6da05",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "ZY-ZTH02z"
   },
   {
@@ -7749,7 +7749,7 @@
     "imageType": 550,
     "manufacturerCode": 4417,
     "sha512": "a67aef253a6de545a7963d6afba4f8e07d50cc9a480d81d544fc43465ddeb55aa1bccc989e536e9f9d1623b0d73fd77da1551e1a9b2bef3f619c95ae0b9f5641",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "ZY-ZTH01-z"
   },
   {
@@ -7760,7 +7760,7 @@
     "imageType": 551,
     "manufacturerCode": 4417,
     "sha512": "14f444fef0a36b861a36e20f44fc5920eb9d68f474238601e6f4b097399e96255cabccf5fb23c0f57d10215b576767bd9f92507cc17331879990cc670ab867bc",
-    "otaHeaderString": "ZigbeeTLc OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ZigbeeTLc OTA",
     "modelId": "ZG227-z"
   },
   {
@@ -7772,7 +7772,7 @@
     "imageType": 54179,
     "manufacturerCode": 4417,
     "sha512": "b08d60804f8c75ffce2c2362e88c473f80a7194a15bd1204c07f60fc9ca0817e5736836f0b9c861683cd2269055e79fbf1ee642f819b8857f1fd93f3dd5ed683",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "manufacturerName": [
       "_TZ3000_x3ewpzyr"
     ]

--- a/index1.json
+++ b/index1.json
@@ -7,7 +7,7 @@
     "imageType": 12298,
     "manufacturerCode": 4617,
     "sha512": "ce5794daa1db129018229d15a4c7340ff2181fdf1374a6c17b7209d2d4a9c48edd7de747298eed5ce6e4862cb7cb706feaf0dc58155984b64bdc02c3f70ff5fc",
-    "otaHeaderString": "RBSH-TRV0-ZB-EU\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "RBSH-TRV0-ZB-EU",
     "modelId": "RBSH-TRV0-ZB-EU"
   },
   {
@@ -18,7 +18,7 @@
     "imageType": 273,
     "manufacturerCode": 4107,
     "sha512": "06c95d8ebf5814909fe95e1de31309a708f1018674eee7f844569abf99befa88cd352d7e8c3a7b001e488732e2246ca34ba69f1f507ac32bcf2df1d64eeef8ba",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://firmware.meethue.com/storage/100b-111/16783872/3f5056e2-e060-4cc4-8f29-28056efc5e6b/100B-0111-01001A00-ConfLight-ModuLum-EFR32MG13.zigbee",
     "releaseNotes": "Various improvements"
   },
@@ -30,7 +30,7 @@
     "imageType": 289,
     "manufacturerCode": 4107,
     "sha512": "b117d19666222b0b1962585f1e47e525c643d3d784fa3a59c0299cd1533a3799a1c72553c7964708879fe0131d4c5cb9fcc5af681d8059d18e6f47b942a5e4fb",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0121/f28229fd-c450-4d0c-ada4-21f855674e06/100B-0121-02003B19-Switch-EFR32MG22-40xf.zigbee"
   },
   {
@@ -41,7 +41,7 @@
     "imageType": 269,
     "manufacturerCode": 4107,
     "sha512": "10e549c55d262b2f227b75817f6620be407f537e04ac08db4dbebdf53e8d460299a2cda248b3be13476757d61a1c79b632963c4f126cd26b7c18ea6a2ab4ac59",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_010D/bd3f218f-190b-4498-b6b3-69aea563fd9d/Sensor-ATmega_6.1.1.27575_0012.sbl-ota"
   },
   {
@@ -52,7 +52,7 @@
     "imageType": 265,
     "manufacturerCode": 4107,
     "sha512": "d20057d6c4e61d4ccdd3947b8a8c9bf9e126a26c080b9ce3e6839a0615b912c6f93246a60c55a44f2c8b8ec49f5041f46ac38b8a3c0a1c6ab44f062cc62089cf",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0109/0e1147ca-9b7e-4de1-b282-8b81c3c8e030/Switch-ATmega_6.1.1.28573_0012.sbl-ota"
   },
   {
@@ -63,7 +63,7 @@
     "imageType": 4552,
     "manufacturerCode": 4476,
     "sha512": "a0e82ae8bab520f7528c01479523d08ebd980fad823040e00ab418a37143dea94a868728b2d428369bdf363eca934ce3345bab752d680167443f0c30f4e3bed8",
-    "otaHeaderString": "EBL tradfri_motion_sensor_2\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL tradfri_motion_sensor_2",
     "originalUrl": "http://fw.ota.homesmart.ikea.net/global/GW1.0/01.21.031/bin/10039874-1.0-TRADFRI-motion-sensor-2-2.0.022.ota.ota.signed",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -75,7 +75,7 @@
     "imageType": 4357,
     "manufacturerCode": 4476,
     "sha512": "2d903d8b28202b9e4ab32c9cf63b9fd25966edc3a21baea45a62854035c021081a55758ad85958fb8830478177af6e2d14d9fe0e296721b42d7cb44c2db84fb5",
-    "otaHeaderString": "GBL zingo_lds_bulb_jetstrom_ws\u0000\u0000",
+    "otaHeaderString": "GBL zingo_lds_bulb_jetstrom_ws",
     "originalUrl": "http://fw.ota.homesmart.ikea.net/global/GW1.0/01.21.031/bin/10115366-zingo_lds_bulb_jetstrom_ws-0x1105-2.4.5-prod.ota.ota.signed",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -87,7 +87,7 @@
     "imageType": 10245,
     "manufacturerCode": 4476,
     "sha512": "c1de6f1b87ecd9b973af6b345749148bebd76ec7e8dd0a9f207ebd90eb4e30bde54aee407972e047d959982cd39c834867bba07318b1ca607871a870d4178f90",
-    "otaHeaderString": "GBL zingo_cws\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "GBL zingo_cws",
     "originalUrl": "https://fw.ota.homesmart.ikea.com/files/zingo-cws_release_prod_v16777272_89b37a10-683a-4183-9ed7-4973bc34994b.ota",
     "releaseNotes": "https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html"
   },
@@ -111,7 +111,7 @@
     "imageType": 257,
     "manufacturerCode": 4655,
     "sha512": "0c0973c9ad5f627b9cd1cfea8c6d4b0e57958378b4ca21b97d9552fa0183eecbb3c3971cf4f965e39c8b974aa3e91653c9ef7a55abe4ae478a67dccc6417b26a",
-    "otaHeaderString": "EBL VM_SWITCH\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL VM_SWITCH",
     "originalUrl": "https://github.com/InovelliUSA/Firmware/raw/main/Blue-Series/Zigbee/VZM31-SN-2-1-Switch/Production/2.15/VZM31-SN_2.15-Production.ota"
   },
   {
@@ -122,7 +122,7 @@
     "imageType": 513,
     "manufacturerCode": 4655,
     "sha512": "a2f991faaac21cd0851d86d1057bddbcc614fbb616e4f2f841402a6bced67465db85e622bd4271a10b740e09a1fe241fa96b660bfc6e4783bd1eceb76b20a64c",
-    "otaHeaderString": "VZM35_MG24\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "VZM35_MG24",
     "originalUrl": "https://files.inovelli.com/firmware/VZM35-SN/Beta/1.05/VZM35-SN_1.05.ota"
   },
   {
@@ -133,7 +133,7 @@
     "imageType": 1025,
     "manufacturerCode": 4655,
     "sha512": "dfbae89d7ff0010527530c995a457fb162f4059f9824bf98b11c27e6146f061d2be5a51ced3a7cba3909ff1ada1135a91b39db39a63e86527bb97ac1636c5a4f",
-    "otaHeaderString": "VMZB_Canopy\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "VMZB_Canopy",
     "originalUrl": "https://inov.li/IRbxhx1646F/VZM36_0.04.ota"
   },
   {
@@ -144,7 +144,7 @@
     "imageType": 61441,
     "manufacturerCode": 61731,
     "sha512": "d2d185fc25b28d8e5ed4323550e630e5ada864add2bafc805b07113d9df9c95b7c37047e535784c0277f4fd5e9d9f06d91a558e4fc2a04080b2d85f9a1999a19",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://fw.jethome.ru/media/firmwares/jethome/zigbee/release/13/jethome_zigbee_release_13_zigbee.ota.zigbee",
     "manufacturerName": [
       "JetHome"
@@ -159,7 +159,7 @@
     "imageType": 61,
     "manufacturerCode": 4489,
     "sha512": "1f61f23360e9e9977623ad3f3486a589c7c7ca151e6de6807151802c0f8b462949a11b4ad59cf35d09ed6977e3d1783d6bba8baa5de574188ba25a4feb1b4248",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=61&version=1.3.100.0",
     "releaseNotes": "1.Support for turn on/off fading time configurations\r\n2.Support for ZLO commands\r\n3.OTA improvements, rollback protection enabled"
   },
@@ -171,7 +171,7 @@
     "imageType": 60,
     "manufacturerCode": 4489,
     "sha512": "8c1492d0bfe3df15c2aff682680ddda821ecc92a2a64276d492551c5faf364bc51a93adcce421bd89ee8fb85fe9f514ad96395535c882d4b9388a5b58149b4c4",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "B40_DIM_Z3_IM0034_01036400-encrypted_202110060421_withoutMF.ota",
@@ -181,7 +181,7 @@
     "imageType": 52,
     "manufacturerCode": 4489,
     "sha512": "a9fd8a3c9c41a224a4aa44b623f3cae80c5e7a651449976eb5bdbcfdea5e95ce41d79cb8dd73c27665782d1223ae288cea53df2735320a6adfb638e674f46afc",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=52&version=1.3.100.0",
     "releaseNotes": "1.Support for turn on/off fading time configurations\r\n2.Support for ZLO commands\r\n3.OTA improvements, rollback protection enabled"
   },
@@ -193,7 +193,7 @@
     "imageType": 51,
     "manufacturerCode": 4489,
     "sha512": "e1fcdbbd11de351d09104de7e0401db047d9d588c3aa4be2352d3a28fc132fecf49ffccd86a68bd8ae30cf0abe6d152d1171f74ad79a98e0963fd7a8ea2220de",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "CLA60_RGBW_Z3_IM0011_00103101-encrypted_11_27_2018_Tue_133608_15_withoutMF.ota",
@@ -203,7 +203,7 @@
     "imageType": 17,
     "manufacturerCode": 4489,
     "sha512": "9e2a43605da677c9a1ead29b896175ef68a5f7862a610c49c29486f512879d813de38401264b5e33a72924bb05297c2777ddf3f25e7bbb0c67eeb261c92a3844",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "DIM-LEDVANCE_DIM-0x1189-0x006F-0x02056550-MF_DIS-20201201111102.ota",
@@ -213,7 +213,7 @@
     "imageType": 111,
     "manufacturerCode": 4489,
     "sha512": "7ad0ac0c049f11bdcf26329b5e1e0339541a67af9c226655d2bfa24115d6d080471ea285f313b854491fc226dca4561788367d9646e65ac9d384efd300db167f",
-    "otaHeaderString": "LEDVANCE_DIM\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "LEDVANCE_DIM",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=111&version=2.5.101.80",
     "releaseNotes": "- LQI attribute reporting improved\r\n- Turn On/Off fading time configuration supported \r\n- On with time off Command supported "
   },
@@ -225,7 +225,7 @@
     "imageType": 135,
     "manufacturerCode": 4489,
     "sha512": "c2ecb73f7cfbd020ff01374c54861ed10058dbdc47051f0a4255f09c7555077f325b5c0aeea89f0fb8fc6c735c6532357e874a8d8de0edfd30fda14dfd7c79a2",
-    "otaHeaderString": "DL_PFM155UGR_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "DL_PFM155UGR_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=135&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0X0B04, attribute 0X0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -237,7 +237,7 @@
     "imageType": 136,
     "manufacturerCode": 4489,
     "sha512": "36d44ca2ebb124ea9db87993f057fca0a2f7cffdddbce77ba7d538ff4c21f31cf3cf7f887aef0dcd4c5646cbac22ffe3f3879134c4f08388cf564698ba7f6005",
-    "otaHeaderString": "DL_PFM195UGR_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "DL_PFM195UGR_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=136&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0X0B04, attribute 0X0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -249,7 +249,7 @@
     "imageType": 132,
     "manufacturerCode": 4489,
     "sha512": "e056f033e84d672a665aa61edc026e44958b3aac4c4f139dbd2ca333cbf1b336b243c2ad2710472b66583a07acaf18856f28cc2956fc0ea28ef7ef91d58f254f",
-    "otaHeaderString": "LN_Indivi1200_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "LN_Indivi1200_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=132&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0X0B04, attribute 0X0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -261,7 +261,7 @@
     "imageType": 133,
     "manufacturerCode": 4489,
     "sha512": "52ec07aba7f8203bece4bb80f2dd39360850557dc143c22c9cccab477fd2c8abc7eef41d2a6c47845a4ad23e2414aa859ed646e0aa2485727a3c7150f62a1834",
-    "otaHeaderString": "LN_Indivi1500_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "LN_Indivi1500_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=133&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0X0B04, attribute 0X0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -273,7 +273,7 @@
     "imageType": 134,
     "manufacturerCode": 4489,
     "sha512": "2a0c1f7d13c6974b04eabd8d9e5578e9cddb5e3914868f9184ed65c6a74c0be5a71082eb5898bcd2f0659f39ce880e9e9ffbedbe6eccfcaa7b25d6f6acf15332",
-    "otaHeaderString": "PL_DI1200_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_DI1200_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=134&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0x0B04, attribute 0x0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -285,7 +285,7 @@
     "imageType": 130,
     "manufacturerCode": 4489,
     "sha512": "d08e24ba455cafba0753c07ee50ee6a6537dc1435448df8947a766250e70eae0695ace1e428beff9132d6015d71902c27dcc67fae66aeedce465a8517dfff634",
-    "otaHeaderString": "PL_Indivi600_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_Indivi600_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=130&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0x0B04, attribute 0x0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -297,7 +297,7 @@
     "imageType": 131,
     "manufacturerCode": 4489,
     "sha512": "f7ec739a22ffd648c1dc6a50e54ae0dd65c07293576fb97363554de631d050f1a9bd90bc399106eed1a72e041f604bb2d225c2ba50826e263efc078cae0f7fe7",
-    "otaHeaderString": "PL_Indivi625_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_Indivi625_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=131&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0x0B04, attribute 0x0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -309,7 +309,7 @@
     "imageType": 128,
     "manufacturerCode": 4489,
     "sha512": "533f0bdac8ed8220a87a3688ab05fdd490997e3e647facbea054209154798d5180abd928a2e0bef954b11fd0cebdeecbf438ae6776656959ea284379677c28f9",
-    "otaHeaderString": "PL_PFM600UGR_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_PFM600UGR_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=128&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0x0B04, attribute 0x0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -321,7 +321,7 @@
     "imageType": 137,
     "manufacturerCode": 4489,
     "sha512": "aed018a1f2a84aa7eb8bb3b1792f9a059938371cf97aece5f87815da9d30255b5f65e5ee5a213a941d5703ebd4e644526e8841ca64423a6d342191492ce0593f",
-    "otaHeaderString": "PL_PFM600_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_PFM600_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=137&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0x0B04, attribute 0x0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -333,7 +333,7 @@
     "imageType": 129,
     "manufacturerCode": 4489,
     "sha512": "651f905729d7ca49e4db9ae567f2926ede695fcde0b1c2cee0320aba70612cbb220013280c03b8182a6334251440e490687bf71301c0dfffe275589454855376",
-    "otaHeaderString": "PL_PFM625UGR_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_PFM625UGR_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=129&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0x0B04, attribute 0x0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -345,7 +345,7 @@
     "imageType": 127,
     "manufacturerCode": 4489,
     "sha512": "6b2f19b887ec01886a786db3ca4510360347df40bf0172b5f50110321a45407bdbe97b855f69ca5b78b65b9e2996f9b2a784350a9f3cef25d0e87f1e12fb0f91",
-    "otaHeaderString": "PL_PFM625_04\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_PFM625_04",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=127&version=2.14.101.80",
     "releaseNotes": "1.Power report using cluster 0x0B04, attribute 0x0304\r\n2.Maximum  group number is 12.\r\n3.Reply group capacity with meaningful value.\r\n4.Support ZLO command.\r\n5.GTIN report for EMMA."
   },
@@ -357,7 +357,7 @@
     "imageType": 150,
     "manufacturerCode": 4489,
     "sha512": "3026348b9c2838f8107d3cc20c824fea5fa0f02c9892fbf7ee17c887f2abb83d4914df0fbf0177700bf3879c212ac41ec6e1056dcf32ab3baa3aace93fb20e57",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=150&version=1.9.100.0",
     "releaseNotes": "\r\n1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix leave network issue when update link key fail."
   },
@@ -369,7 +369,7 @@
     "imageType": 42,
     "manufacturerCode": 4489,
     "sha512": "de28f435a8b3529eeb299312d1d9cd7c58234ac6136c96baab1ac6a096b6773eba556525d2fd4aa62833a35b1acf4231b852ebf5fd6609edce21c030c56a90ba",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "Gardenpole_Mini_RGBW_Z3_IM0040_00103103-encrypted_02_27_2019_Wed_151557_92_withoutMF.ota",
@@ -379,7 +379,7 @@
     "imageType": 64,
     "manufacturerCode": 4489,
     "sha512": "e8c7ab6df0371b38906ad5547f30ff33a57b4895ff975debc8560bcf8fa88ffd19a251cef76e20364951c074ddf00b89c704b23f651e58571f732c84d16dd494",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "Gardenpole_RGBW_Z3_IM003B_00103103-encrypted_02_27_2019_Wed_150725_31_withoutMF.ota",
@@ -389,7 +389,7 @@
     "imageType": 59,
     "manufacturerCode": 4489,
     "sha512": "d9efbe7a2c2076b2114ddb843d512c30dee150be7245ca70e44df81bf7133154535230f1d2c011413e6955a55953a508980b6121df94b831b97783f25e200b6b",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "Outdoor_FLEX_RGBW_Z3_IM005C_00103101-encrypted_11_27_2018_Tue_135739_87_withoutMF.ota",
@@ -399,7 +399,7 @@
     "imageType": 92,
     "manufacturerCode": 4489,
     "sha512": "4b0155dbda42e3037811628dd0f94d35b52ac7b5282fc98b60fa9356f76588c7bf265c80dc0dd005cc5270b1bd84ed2db9bd2fb9b0653f68883f983f4bf0485a",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "PAR16_DIM_Z3_IM0031_01036400-encrypted_202110060424_withoutMF.ota",
@@ -409,7 +409,7 @@
     "imageType": 49,
     "manufacturerCode": 4489,
     "sha512": "4aefb57323b9ab099797b8e502514d817500c34f86e0d55f6c5bfee853acae66bbaab8987c169e7b734df81ea321d15c01d970dc5dfbabed2698d14bd7e6bdda",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=49&version=1.3.100.0",
     "releaseNotes": "1.Support for turn on/off fading time configurations\r\n2.Support for ZLO commands\r\n3.OTA improvements, rollback protection enabled"
   },
@@ -421,7 +421,7 @@
     "imageType": 48,
     "manufacturerCode": 4489,
     "sha512": "1f1378753629c6a1d014b7e4cb7c750261c8eafab452bbd63c4fa2b427fde7d12e52b9658972425e1024a29145034fba822afd4c8f1b91039006f515192b621d",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "PAR16_TW_Z3_IM002E_00103101-encrypted_11_23_2018_Fri_162418_58_withoutMF.ota",
@@ -431,7 +431,7 @@
     "imageType": 46,
     "manufacturerCode": 4489,
     "sha512": "0635909cb05a5e9c1b4d2f92f4787fa35aa4804dbebed1db72375e06774084aece3856986d0c4a3a0d764f5a54ddc07cb5528f3755347ab3924bf0a0062f977b",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "PLUG-Plug_Value-0x1189-0x0067-0x02056550-MF_DIS-20201216170637.ota",
@@ -441,7 +441,7 @@
     "imageType": 103,
     "manufacturerCode": 4489,
     "sha512": "36f586dad5dc74d52d5ad252b07d714dc87b25ba13e99669e7a2fa1c85f8fbe5b28b569e890b3b0c19a7a8352121b69a3fc2475548df700e5b15b9920c81d8cf",
-    "otaHeaderString": "Plug_Value\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Plug_Value",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=103&version=2.5.101.80",
     "releaseNotes": "- LQI attribute reporting improved\r\n- Turn On/Off fading time configuration supported\r\n- On with time off Command supported"
   },
@@ -453,7 +453,7 @@
     "imageType": 194,
     "manufacturerCode": 4489,
     "sha512": "9fe0089e552041016ca6a182ad727fa4b60b6b6732d2ec2fe80bffdf631b7de1a787f8aa2bb5611df7a6ae62be49df27a7afbab61952135a75ab09cc7f221db7",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=194&version=3.32.54.114",
     "releaseNotes": "1. Support maximum 30 groups\r\n2. Enable the watchdog\r\n3. Set the Tx power to 9.8dB"
   },
@@ -465,7 +465,7 @@
     "imageType": 149,
     "manufacturerCode": 4489,
     "sha512": "640e4f27245ee51d7f34f94df1a61e71e92be471d1934febbefbfd20d30ab1a91540b091315446eca08040c4afd50a1762cde082b7ec1dc9a156297191f32c0c",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=149&version=1.9.100.0",
     "releaseNotes": "\r\n1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix leave network issue when update link key fail."
   },
@@ -477,7 +477,7 @@
     "imageType": 148,
     "manufacturerCode": 4489,
     "sha512": "43045492a4f9abcc90cd99239a50c024a923942118fd00b33dcbe36da7cbee627170a9e002f4d6589fec82cc01b9a2cf6d8f5ae332e2faa647a5abc58f9a009d",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=148&version=1.9.100.0",
     "releaseNotes": "\r\n1. Support GP switch.\r\n2. Improve network performance by fine tune router table.\r\n3. Fix leave network issue when update link key fail."
   },
@@ -489,7 +489,7 @@
     "imageType": 90,
     "manufacturerCode": 4489,
     "sha512": "2e018b75b5566ceb0c7c98788fa21aeb7b3aa8259ae85762a7a68fe7ee9d29733222b870edcbfcc0a34108369f8e21a1f2a91ecb6737dedb5fd7c0b4db4a3818",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "RGBW-A60S_RGBW-0x1189-0x00A0-0x02146550-MF_DIS-20211203082926-3221010102432.ota",
@@ -499,7 +499,7 @@
     "imageType": 160,
     "manufacturerCode": 4489,
     "sha512": "1f8c83539c60a71fedd28190e71b5354f963b92f1c1706579a3c8ba847d68dfc8412a46ab3bf678da5396c88cc35d2a03c64c8015d686e1553107c38e3eb6117",
-    "otaHeaderString": "A60S_RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "A60S_RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=160&version=2.20.101.80",
     "releaseNotes": "1.ZLO gap fix\r\n2.RGBW color calibration\r\n3.Disable touch-link function"
   },
@@ -511,7 +511,7 @@
     "imageType": 138,
     "manufacturerCode": 4489,
     "sha512": "af4ac5603537d2c151e9d0b7090abf546866e037ac43c3b81844d8ebad2994d0330916450b1032d64b331baedecfa750404f19b0739573a5b4afbe6c7741b677",
-    "otaHeaderString": "A60_RGBW_Value_II\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "A60_RGBW_Value_II",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=138&version=2.20.101.80",
     "releaseNotes": "1.ZLO gap fix\r\n2.RGBW color calibration\r\n3.Disable touch-link function"
   },
@@ -523,7 +523,7 @@
     "imageType": 166,
     "manufacturerCode": 4489,
     "sha512": "e3d1e301391111bec1a318e54cf40e4059d89c05b8f2f5c673818142076008a38826412036a78baa16e85cf74b0f73e11ff4f942d8d084c3ca3f743dc64524b6",
-    "otaHeaderString": "PAR16S_RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PAR16S_RGBW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=166&version=2.20.101.80",
     "releaseNotes": "1.ZLO gap fix\r\n2.RGBW color calibration\r\n3.Disable touch-link function"
   },
@@ -535,7 +535,7 @@
     "imageType": 142,
     "manufacturerCode": 4489,
     "sha512": "4382e5813f4b35734f981d66f9261ba8c9680a32c7d73388a1d82548dda79985dc59223f827af4bf69eb0935d7b4c172c0bbb8cfc655a71da64b37139dae3917",
-    "otaHeaderString": "PAR16_RGBW_Value\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PAR16_RGBW_Value",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=142&version=2.20.101.80",
     "releaseNotes": "1.ZLO gap fix\r\n2.RGBW color calibration\r\n3.Disable touch-link function"
   },
@@ -547,7 +547,7 @@
     "imageType": 162,
     "manufacturerCode": 4489,
     "sha512": "5d4e31dcffd9dd2724a8a7e355870563f71c7d3b3cefcb1fd169073bb77ca9a66f25b2bea0d2ba5979cfcb0c875904a5024808aaa2f2524afebc6ec2f65807f4",
-    "otaHeaderString": "A60S_TW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "A60S_TW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=162&version=2.19.101.80",
     "releaseNotes": "1． ZLO gap fixed.\r\n2． V02136550 is production firmware."
   },
@@ -559,7 +559,7 @@
     "imageType": 139,
     "manufacturerCode": 4489,
     "sha512": "9f06268c2dee0c2d2409053a5e70ae90c2254df44c5d535be190dce8cf990ce132e84f509af07d43247b9ae412267993deaaa748b0e120c25b64332c7f7eca10",
-    "otaHeaderString": "A60_TW_Value_II\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "A60_TW_Value_II",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=139&version=2.3.101.80",
     "releaseNotes": "- LQI attribute reporting improved\r\n- Turn On/Off fading time configuration supported \r\n- On with time off Command supported "
   },
@@ -571,7 +571,7 @@
     "imageType": 163,
     "manufacturerCode": 4489,
     "sha512": "6ffd79073587c1f69da51a09ed3a88d9c4f85fd6530f0f01ab496f2ab5a6ee563b7fe0209e65f0ab198113abc42ef7f4aac79d8f53628eb1afcfe384d9514642",
-    "otaHeaderString": "B40S_TW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "B40S_TW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=163&version=2.19.101.80",
     "releaseNotes": "1． ZLO gap fixed.\r\n2． V02136550 is production firmware."
   },
@@ -583,7 +583,7 @@
     "imageType": 140,
     "manufacturerCode": 4489,
     "sha512": "9705e0af2c81c7a6b5cb35be7d9354e3d5cbd2c5af060a423f5bb96d10bd1eaf94674160c7d54ee55ca6df78d60bb6e3901a24ba214ac0ca7dd354d013d61211",
-    "otaHeaderString": "B40_TW_Value\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "B40_TW_Value",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=140&version=2.5.101.80",
     "releaseNotes": "- LQI attribute reporting improved\r\n- Turn On/Off fading time configuration supported \r\n- On with time off Command supported"
   },
@@ -595,7 +595,7 @@
     "imageType": 164,
     "manufacturerCode": 4489,
     "sha512": "c1b77a74781839a2c98bdd32c7c2d541cd348f79924a0ed07ab8f96c9b9061f987af106c71c6fd2cd659bc244823e3433dd1f7766705bc6ca484f6d3157b5073",
-    "otaHeaderString": "P40S_TW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "P40S_TW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=164&version=2.19.101.80",
     "releaseNotes": "1． ZLO gap fixed.\r\n2． V02136550 is production firmware."
   },
@@ -607,7 +607,7 @@
     "imageType": 141,
     "manufacturerCode": 4489,
     "sha512": "845d40e0b2b8d5f9cc6d51e2ac0459c6628eef11bb2754cbb9140cfeeb5a7fb21bddf5bdeedb573ab745cbd793bc8ef77b1fd0ca3ed57a60ed4cdc3e9d6f11ff",
-    "otaHeaderString": "P40_TW_Value\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "P40_TW_Value",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=141&version=2.5.101.80",
     "releaseNotes": "- LQI attribute reporting improved\r\n- Turn On/Off fading time configuration supported \r\n- On with time off Command supported"
   },
@@ -619,7 +619,7 @@
     "imageType": 165,
     "manufacturerCode": 4489,
     "sha512": "6add01e835ac970eed7b90fa84b79558ede7622f07ae9386c2afd86ac5aa8f1918702c9ef5e8e79a8b93e2f411ffed900e2d064e9ecf52a2d23918bacfdd8be5",
-    "otaHeaderString": "PAR16S_TW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PAR16S_TW",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=165&version=2.19.101.80",
     "releaseNotes": "1． ZLO gap fixed.\r\n2． V02136550 is production firmware."
   },
@@ -631,7 +631,7 @@
     "imageType": 143,
     "manufacturerCode": 4489,
     "sha512": "6d6b34da8a97c6bf75b3eeed62a986722cfdd23a5657dd4391f8c62579b42c8d0928c3bddd6e7467cded5c3849ea041852955c679a8d29c1920a90f52409619e",
-    "otaHeaderString": "PAR16_TW_Value\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PAR16_TW_Value",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=143&version=2.5.101.80",
     "releaseNotes": "- LQI attribute reporting improved\r\n- Turn On/Off fading time configuration supported \r\n- On with time off Command supported "
   },
@@ -643,7 +643,7 @@
     "imageType": 187,
     "manufacturerCode": 4489,
     "sha512": "940d5c4702ebcda1e0f145b7b79fa1050a808c6972b07f46046b20b5cb47a5df3d157c22b6a1f3a941d1bba08264a60cd17dc5306d78830fcff2a9de0e989905",
-    "otaHeaderString": "DL_HCL_ND150_02\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "DL_HCL_ND150_02",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=187&version=2.34.101.80",
     "releaseNotes": "1. Enable permanent beacon request before Luminaire finish network paring.\r\n2. Patch to pass Zigbee3.0 certification.\r\n3. Improve fading function."
   },
@@ -655,7 +655,7 @@
     "imageType": 188,
     "manufacturerCode": 4489,
     "sha512": "3c4123050fa02013fd41a2786fdd7d309373b4cbaef31761416e96aa67f80227f088e920f5030b22994ecaccb3e60373e8891182af3eb131cdd5af059b6eb4cf",
-    "otaHeaderString": "PL_HCL300x1200_01\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_HCL300x1200_01",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=188&version=2.34.101.80",
     "releaseNotes": "1. Enable permanent beacon request before Luminaire finish network paring.\r\n2. Patch for Zigbee3.0 certification.\r\n3. Improve fading function."
   },
@@ -667,7 +667,7 @@
     "imageType": 185,
     "manufacturerCode": 4489,
     "sha512": "2ebc8d54d1e55274abdbba8ed227c21b27ee1f69e3a85ebd6e3ac0fb42c1fe1fca94b1b6e7ef044c4263c69898494dcb5ee469db2aa5ed79c1f06519c20d08a8",
-    "otaHeaderString": "PL_HCL600_02\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_HCL600_02",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=185&version=2.34.101.80",
     "releaseNotes": "1. Enable permanent beacon request before Luminaire finish network paring.\r\n2. Patch for Zigbee3.0 certification.\r\n3. Improve fading function."
   },
@@ -679,7 +679,7 @@
     "imageType": 186,
     "manufacturerCode": 4489,
     "sha512": "a3f9c3327251024d8a890aeff57b90711e87c7a0264663bcc60b3a92f0ca6d91babbe2031009d75cb26aceffb317ae0c78ab31059066a2df0567c5809fccc424",
-    "otaHeaderString": "PL_HCL625_02\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "PL_HCL625_02",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=186&version=2.34.101.80",
     "releaseNotes": "1. Enable permanent beacon request before Luminaire finish network paring.\r\n2. Patch for Zigbee3.0 certification.\r\n3. Improve fading function."
   },
@@ -691,7 +691,7 @@
     "imageType": 44,
     "manufacturerCode": 4489,
     "sha512": "ae34bd7dc48ce19fde6c469ba072131c6c900b7d8735642c91fef6a7c7fee4729bde40a741a3190a13ac262db2342566b3fc33efa0bf14fee263ce0043571715",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "Undercabinet_TW_Z3_IM0046_00103101-encrypted_11_20_2018_Tue_101550_96_withoutMF.ota",
@@ -701,7 +701,7 @@
     "imageType": 70,
     "manufacturerCode": 4489,
     "sha512": "ded526b4f6bec5eec748bd4b7a8c4a3e7aceb49d14793c3537b5b16ddf35bfcb974f00a4816adab62aae46a4e3e822626649645fa2154521705891006f5010a6",
-    "otaHeaderString": "EBL RGBW\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGBW"
   },
   {
     "fileName": "VIVARES_PBC4_01_0x10102503.ota",
@@ -711,7 +711,7 @@
     "imageType": 152,
     "manufacturerCode": 4489,
     "sha512": "ec76c7f56cf8071f81f32ce81ec629ca60d155de7db0890b9ab85e5f0a7a2dbe5aa72b70a52066de998d0c620900788310c63e3e425b16db025c221e449d8cb8",
-    "otaHeaderString": "VIVARES_PBC4_01\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "VIVARES_PBC4_01",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=152&version=16.16.37.3",
     "releaseNotes": "1.Add reset function by 10s long press prog button\r\n2.Fix network pairig issue. (The issue is that only 6 beacon request sent out and then PBC stop beacon request)\r\n3.Fix the issue that push button configure for 4 channels missing after OTA upgrade.\r\n"
   },
@@ -723,7 +723,7 @@
     "imageType": 124,
     "manufacturerCode": 4489,
     "sha512": "9509f4a2c7afb405b9b7a1493256caac47ad595c328f8ada66b538607859e29883dd3d42a94ba9b84a1a2f7aa4dc42c098dd77fcb9167a761edeca98bf3eef9b",
-    "otaHeaderString": "EBL AcSensor_Y\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL AcSensor_Y",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=124&version=17.49.102.48",
     "releaseNotes": "   1. Blink red LED indicator when sensor receives identify command.\r\n   2. Fix network paring bug that related with network link key.\r\n   3. Add Zigbee cluster for Zigbee certification test.\r\n   4. Support GTIN reporting for EMMA."
   },
@@ -735,7 +735,7 @@
     "imageType": 151,
     "manufacturerCode": 4489,
     "sha512": "e8265eef2c2118c784f0e2c7ce5e880f3785f7c6a6f3fb17d6b711c421f006d40d2b52dd09aadbfd7ae63b5719bf5611a88254adcd953b9c9cb55f3aa233e78f",
-    "otaHeaderString": "EBL AcSensor_Y\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "EBL AcSensor_Y",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4489&product=151&version=17.40.102.48",
     "releaseNotes": "   1. Blink red LED indicator when sensor receives identify command.\r\n   2. Fix network paring bug that related with network link key.\r\n   3. Add Zigbee cluster for Zigbee certification test.\r\n   4. Support GTIN reporting for EMMA."
   },
@@ -747,7 +747,7 @@
     "imageType": 57374,
     "manufacturerCode": 4364,
     "sha512": "ffa864626513dabd3fc88ba11f1e8343b59f5d0afee219d56c7ace8bc6ee107c6d9020470235591304c2281546f5996b61dedaca2325e3bd3f61d426312f1835",
-    "otaHeaderString": "Zigbee3toDALIConverter\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Zigbee3toDALIConverter",
     "originalUrl": "https://api.update.ledvance.com/v1/zigbee/firmwares/download?company=4364&product=57374&version=16.9.101.91",
     "releaseNotes": "Optimized broadcast and multicast message forwarding in large networks"
   },
@@ -822,7 +822,7 @@
     "imageType": 6416,
     "manufacturerCode": 4447,
     "sha512": "bed1de09ca57d6f9d04e2503fe52c79db4d1daf9706c9f169507897609853cacc45c875860bb6853bfde7226ef0da861dba952c9e2b177e90b31002bf0e4daeb",
-    "otaHeaderString": "Aqara OTA Image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Aqara OTA Image",
     "modelId": "lumi.switch.acn047"
   },
   {
@@ -888,7 +888,7 @@
     "imageType": 1000,
     "manufacturerCode": 4714,
     "sha512": "524608958eb54909a76e5a555b18a34ac4917d504b48bdf6593898213f8aec1ae814d8e0270ebe7f983fb8c73f78a5afc7390e98e07f86ec6b2a9df7f4a9eaba",
-    "otaHeaderString": "EBL D581_ZG\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL D581_ZG"
   },
   {
     "fileName": "128b-0002-0304-700_nodon_sin_2_fw_efr32_V0304.zigbee",
@@ -898,7 +898,7 @@
     "imageType": 2,
     "manufacturerCode": 4747,
     "sha512": "0b9c29f9f10c3121d67e97489fd6fd3e9973a159f2b2364c02733e99d5ae8d6461a11ff76cbf1dff99197308f1e94fef2373be223d47d2d65a70ab2621601b2a",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0005-0304-700_nodon_sin_met_fw_efr32_V0304.zigbee",
@@ -908,7 +908,7 @@
     "imageType": 5,
     "manufacturerCode": 4747,
     "sha512": "b82f0486a32cea87c894e1e5765bf7e5940a67ca7ed06d664b2d369c15b87b5ff8d0410516152168b959cdca0a490d83abef3736c00e3d3edd315e0a959f42af",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0006-0304-700_nodon_sin_fp_fw_efr32_V0304.zigbee",
@@ -918,7 +918,7 @@
     "imageType": 6,
     "manufacturerCode": 4747,
     "sha512": "cc859821cddf6792b9c6582b846a2d5dfcfa6dd0a1188a4012ccb4d978904bef37458cea967bb86255b10c34a86800ac96cb284ddb1af6c2dbaf4e2e55880a52",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0009-0304-700_nodon_sin_rs_fw_efr32_V0304.zigbee",
@@ -928,7 +928,7 @@
     "imageType": 9,
     "manufacturerCode": 4747,
     "sha512": "512aa9ad34446126ec33cac8d1dcb4e4592395551d8b2baaf66e1dfd88cf8837100f2a17c3580384964a5662b0ed3de554c45d7c3d3ed8750ea6ee6e1256ba8a",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-000A-0304-700_p1771_nodon_sin_1_fw_efr32_V0304.zigbee",
@@ -938,7 +938,7 @@
     "imageType": 10,
     "manufacturerCode": 4747,
     "sha512": "ef50dc8d3aaa2e2c31618c113436f3f3b830c20d0779a633517fb0b1e68b8fee848e2c388c22e986885cdb0c6d83983950e78d821c8a55071b83fa4c354f469e",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "zbminir2_v1.0.2.ota",
@@ -948,7 +948,7 @@
     "imageType": 8,
     "manufacturerCode": 4742,
     "sha512": "b5c5a93ab84607292248e5262ccf0b8c250326d6ed5395c0d8818697b4286df5d85567a63bad7734a959bbaf58b83f9289ff027783284b11de5dfea8a48921ba",
-    "otaHeaderString": "ota-file-test\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "ota-file-test"
   },
   {
     "fileName": "zb_wb_msw4_mg21_063.ota",
@@ -958,7 +958,7 @@
     "imageType": 15,
     "manufacturerCode": 26214,
     "sha512": "0cfc487b13ba17154473622e6cbcc710dd173549803e41cbd7dd260486467e95cb93b5ebf34172456c8bb67ad706d3b95a36d4d7357614b6a7103623ae3403a8",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "zb_wb_msw4_mgm21_063.ota",
@@ -968,7 +968,7 @@
     "imageType": 13,
     "manufacturerCode": 26214,
     "sha512": "e6bbf566a764fa54292067ab375bd8f0490dcc9520df3b1540094c2b7c0983084b11b520136ec2ad15d363726a1deb4980c0f37987bad4bb8a1b9b530f08ec3d",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "SmartPlug_Zigbee_PROD_OTA_V88_v1.00.88.ota",
@@ -978,7 +978,7 @@
     "imageType": 54182,
     "manufacturerCode": 4659,
     "sha512": "fb5b099839d09235929122c113d5af7311ce35afa54b8032d3a5b2d06746c673d2ba27556a2df6dfc9afc8df2c098696cb6f449cdec2869d6c45a8523a5568d6",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://tr-zha.s3.amazonaws.com/z2m_firmware/SmartPlug_Zigbee_PROD_OTA_V88_v1.00.88.ota"
   },
   {
@@ -989,7 +989,7 @@
     "imageType": 54181,
     "manufacturerCode": 4659,
     "sha512": "39f22a3ef9eac451b9dde671650db324082af90452bc39c1184fe22cdbde02d89efdebf401a2ede487e15a9ef333e71f3792d3470da3aa040a1921ff24e520ba",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "Telink OTA Sample Usage",
     "originalUrl": "https://tr-zha.s3.amazonaws.com/z2m_firmware/SmartSwitchGen3_PROD_OTA_V29_v1.00.29.ota"
   },
   {
@@ -1000,7 +1000,7 @@
     "imageType": 31489,
     "manufacturerCode": 4338,
     "sha512": "2dc6106e357107b6e36eb1fdb78e62108f04c6635608b1e58bad89a203f00be8fa8b44beb9b4a4f29e5278fa4a4c00d606a0ab8415e8b42c064772f2c48eb19f",
-    "otaHeaderString": "ubisys D1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B01-0000-0006-01110206-spo-fmd.ota.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -1013,7 +1013,7 @@
     "imageType": 31491,
     "manufacturerCode": 4338,
     "sha512": "6854c83722a924171843254ec3896a3ca6c720f5713cf5d5ca58844e5ecc03978c72e3769874c21d5fa856928d075ba0ce6bf05e5bae7c49454862d5746aad09",
-    "otaHeaderString": "ubisys S2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B03-0000-0006-010E0206-spo-fms2.ota.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -1026,7 +1026,7 @@
     "imageType": 31492,
     "manufacturerCode": 4338,
     "sha512": "8ff58cc1ed046df97e52cb8a40b608913d2827f038286739b1c8a6ba7430c7db7683a643c4a1a403ba428df97371e384fcb5f0eebb8f90d4b9dba1c454141842",
-    "otaHeaderString": "ubisys J1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys J1",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B04-0000-0007-01160206-spo-fmsh.ota.zigbee",
     "hardwareVersionMax": 7,
     "hardwareVersionMin": 0
@@ -1039,7 +1039,7 @@
     "imageType": 31493,
     "manufacturerCode": 4338,
     "sha512": "c7ad49a637ccda86cecce4e6f70be476852f04a8932015339c3286d0418d1954d9d840264032ef4dcb9c9f79eb3c9efa7d34eb79662ee8c2d475511350865212",
-    "otaHeaderString": "ubisys S1-R\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1-R",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B05-0000-0004-010F0206-spo-rms.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1052,7 +1052,7 @@
     "imageType": 31494,
     "manufacturerCode": 4338,
     "sha512": "55abe3c7586a905fe89262cf5d89003d3a160f280f5111a3b33c0dcbab824672e4120818e4ef8bedaf43e45046426db3f2919bd603fc4cee761bcc22c8e0563d",
-    "otaHeaderString": "ubisys S2-R\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S2-R",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B06-0000-0004-010E0206-spo-rms2.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1065,7 +1065,7 @@
     "imageType": 31495,
     "manufacturerCode": 4338,
     "sha512": "5a809965a412a5a12efb8b1d43647c380bd423b186d661a204b0c918bcaeb013812c35ff66b0fa63272f3ea825685dc4f48a2f8806a902b036b519d3663fcf5e",
-    "otaHeaderString": "ubisys J1-R\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys J1-R",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B07-0000-0004-01160206-spo-rmsh.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1078,7 +1078,7 @@
     "imageType": 31496,
     "manufacturerCode": 4338,
     "sha512": "4f6fe672199e13eaae943664b4fd66ff8bd7001ced6066210507e459296f2371102ce4d44dcc2749f1f1393a883907bacb6aaccc5098b222a812769bb00fce7a",
-    "otaHeaderString": "ubisys D1-R\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1-R",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B08-0000-0004-01110206-spo-rmd.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1091,7 +1091,7 @@
     "imageType": 31497,
     "manufacturerCode": 4338,
     "sha512": "71766a73e253d1bd5f1ddceb97891f6f26e099236f31de960628a28f7d59962a3a83c035cde599fceac82055f36bef5d0e16cc45ea915edde9a1aa0ccd047338",
-    "otaHeaderString": "ubisys C4\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys C4",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B09-0000-0004-01090206-spo-fmi4.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1104,7 +1104,7 @@
     "imageType": 31498,
     "manufacturerCode": 4338,
     "sha512": "90e474278dd4005a7f5e28cf8ad8269db8c8ba635a93beef930e1377644fcc547ae81385fc286dd988d8af267d0c4d3eec02726acd35fc26e8ea66dc2e6ca9bc",
-    "otaHeaderString": "ubisys R0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys R0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B0A-0000-0005-010A0206-m7b-r0.ota.zigbee",
     "hardwareVersionMax": 5,
     "hardwareVersionMin": 0
@@ -1117,7 +1117,7 @@
     "imageType": 31499,
     "manufacturerCode": 4338,
     "sha512": "22e7a692fdc34efd1dafb81964a6c6a45b72522a6fdd1e7caf3d4668a2fc78c5fc4ede66a30b75033511af78659568ff13b7b224c5817dd8da47ce10ad6dbead",
-    "otaHeaderString": "ubisys H10\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys H10",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B0B-0000-0001-01000206-m7b-h10.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -1130,7 +1130,7 @@
     "imageType": 31501,
     "manufacturerCode": 4338,
     "sha512": "36e90e275faa9ec8a48e3572664a74badf3631ede4bcce01d4874da09e7fbf0c1c5f3945e201e503ec5a89ea5fb31b662409d4eec92b3ad00d8d25dc564858c5",
-    "otaHeaderString": "ubisys H1 1.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys H1 1.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B0D-0000-0001-01400422-m7b-h1.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -1143,7 +1143,7 @@
     "imageType": 31505,
     "manufacturerCode": 4338,
     "sha512": "3fd077e6ec1cd05d4b49215b0eb7a214b430774c77125e604c682fcba750c46d660d8a7536ca096e958c048b9458fa260380c0f16fd56eff72769649ab60f3f7",
-    "otaHeaderString": "ubisys LD6 0.9.2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys LD6 0.9.2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B11-0000-0001-00920210-m7b-ld6.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -1156,7 +1156,7 @@
     "imageType": 31521,
     "manufacturerCode": 4338,
     "sha512": "ccdb5713ed110470f3eea3ef63620530cdd074d2cee97cf38f583bfb4b2a21a81fc1c9e86b5bfde9aba5dd1df68eca1e746d14944d9a1a0a1479758576b9965c",
-    "otaHeaderString": "ubisys D1 1.9.3\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1 1.9.3",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B21-0000-0006-0193020E-spo-fmd.ota.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -1169,7 +1169,7 @@
     "imageType": 31528,
     "manufacturerCode": 4338,
     "sha512": "a868a68d190960b56392b9a1b4196cc49df476aaae7fa21d0743061759a7b59fb2b4f54c505350bc7939c225e63ca5ef1b7110fcda8c235225c8520e8bf81a54",
-    "otaHeaderString": "ubisys D1-R 1.9.4\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1-R 1.9.4",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B28-0000-0004-0194020E-spo-rmd.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1182,7 +1182,7 @@
     "imageType": 31529,
     "manufacturerCode": 4338,
     "sha512": "9d0b1acee300b3200c2f9efe50ad72c9d864522aebf978b7ba79a0098c089f5f2cb9fd312dda6a8b515d7797ab0c37c2b176bedaf78b39c4e941e445406f25b8",
-    "otaHeaderString": "ubisys C4 1.9.3\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys C4 1.9.3",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B29-0000-0004-01930221-spo-fmi4.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1195,7 +1195,7 @@
     "imageType": 31530,
     "manufacturerCode": 4338,
     "sha512": "42fd3d21624d0283b5b167e74804c0481aa813edae9ea3e0ec8f1bb96479b4d51bd1b0fa25f5d617e4d611b29a3447b0402f3fb61a3a66044ca8fa008667f0be",
-    "otaHeaderString": "ubisys R0 2.0.0#e976528\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys R0 2.0.0#e976528",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B2A-0000-0005-02000230-m7b-r0.ota.zigbee",
     "hardwareVersionMax": 5,
     "hardwareVersionMin": 0
@@ -1208,7 +1208,7 @@
     "imageType": 31532,
     "manufacturerCode": 4338,
     "sha512": "1cb16faf53f5d33f4a83a548b33e56a30fb208d5cbf696d31c003f7b5a40da0de7a3ee7235189478eec60885328ee79b2de0341725c6522da59f047273fb40f2",
-    "otaHeaderString": "ubisys LD6 1.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys LD6 1.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B2C-0000-0001-01400431-ld6.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -1221,7 +1221,7 @@
     "imageType": 31533,
     "manufacturerCode": 4338,
     "sha512": "9dfbcdbf4cbb323fc8293fb3ae38fc9bc5da2e4f94344f5aa1f9e734a4a58816c4cb3041c1f044783aee3d6c9c3cd87b1549f24aac49834eb748235df81d2fa2",
-    "otaHeaderString": "ubisys H1 1.5.2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys H1 1.5.2",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B2D-0000-0001-01520430-m7b-h1.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -1234,7 +1234,7 @@
     "imageType": 31537,
     "manufacturerCode": 4338,
     "sha512": "e94b9ef507740684070decb000f36dadaf90becbf235b1fad67af85cc6401b956f5f76dd67351498a3d228ae696c49a863c4abe3269998b4d398347f8721ac77",
-    "otaHeaderString": "ubisys D1 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B31-0000-0006-02400432-spo-fmd.ota.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -1247,7 +1247,7 @@
     "imageType": 31539,
     "manufacturerCode": 4338,
     "sha512": "94bdae3e03c300e184c904ace1079f80e5afbb0cad687afee0e7ed09c7f55298cf7400db5eb649cd8ca4b46e6d40619fa7add45d269239e2934453a67e10fb56",
-    "otaHeaderString": "ubisys S2 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S2 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B33-0000-0006-02400432-spo-fms2.ota.zigbee",
     "hardwareVersionMax": 6,
     "hardwareVersionMin": 0
@@ -1260,7 +1260,7 @@
     "imageType": 31540,
     "manufacturerCode": 4338,
     "sha512": "1ca2dafe6af27c5e6327e1b213c41b004710c19ffb31aee361ea1341a18d475f6d74a9abdfade4e7f6117966b326b28e2efbcc9bad8e0c9881d8d6d54a37aec2",
-    "otaHeaderString": "ubisys J1 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys J1 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B34-0000-0007-02400432-spo-fmsh.ota.zigbee",
     "hardwareVersionMax": 7,
     "hardwareVersionMin": 0
@@ -1273,7 +1273,7 @@
     "imageType": 31541,
     "manufacturerCode": 4338,
     "sha512": "25502b66ba8b985195019d8e97a2cb7fdc766c85b16d274d67e22498675e27705555cbdb7735fe8dcd8816926af7bd63904aa2f4d8cf81e726af0de803bf8155",
-    "otaHeaderString": "ubisys S1-R 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1-R 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B35-0000-0004-02400432-spo-rms.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1286,7 +1286,7 @@
     "imageType": 31542,
     "manufacturerCode": 4338,
     "sha512": "c55cd3e9abfce3a69495bfb8253342eb99eac8c9f10b1406dbcfc50e24a80a57875c92592dafb5b936e97e26bb313b3423831d6e0a7f4acab537caa550e0b40e",
-    "otaHeaderString": "ubisys S2-R 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S2-R 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B36-0000-0004-02400432-spo-rms2.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1299,7 +1299,7 @@
     "imageType": 31543,
     "manufacturerCode": 4338,
     "sha512": "72e7b22d8005e2c3413e66e3b6ac64e4be6c74b770005c1339dddd2ecc8e56cf7609ad1bfaaaa67013d3baccc21e1f8bead77155f778ba8041475f334e25c0aa",
-    "otaHeaderString": "ubisys J1-R 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys J1-R 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B37-0000-0004-02400432-spo-rmsh.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1312,7 +1312,7 @@
     "imageType": 31544,
     "manufacturerCode": 4338,
     "sha512": "2675460d00aeb9ff3d0a070ff854251bd2cb34f4124b628a900b005915a8a068453f75e416347bc80ffe1af2b4b6b12ed48d0a6c9756d5baeee22ea1d689204f",
-    "otaHeaderString": "ubisys D1-R 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys D1-R 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B38-0000-0004-02400432-spo-rmd.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1325,7 +1325,7 @@
     "imageType": 31545,
     "manufacturerCode": 4338,
     "sha512": "9ca3ac1682ae46979b2465ad517424270ba2569012f72a6627c852410d5225e9a6dd2e5df763761ebd597c48292d207594c5b248930f87ac925a5bdbe313fced",
-    "otaHeaderString": "ubisys C4 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys C4 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B39-0000-0004-02400432-spo-fmi4.ota.zigbee",
     "hardwareVersionMax": 4,
     "hardwareVersionMin": 0
@@ -1338,7 +1338,7 @@
     "imageType": 31546,
     "manufacturerCode": 4338,
     "sha512": "fba15fad16550cc8ef7b8191a9563b0eef7367769aaf53cb49e7f72ebb656dfe7a4648012e7d7b7994156a96263c50321b9e225aeaac207f85c495daac85c8e1",
-    "otaHeaderString": "ubisys R0 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys R0 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B3A-0000-0005-02400432-m7b-r0.ota.zigbee",
     "hardwareVersionMax": 5,
     "hardwareVersionMin": 0
@@ -1351,7 +1351,7 @@
     "imageType": 31547,
     "manufacturerCode": 4338,
     "sha512": "1b4e03ea74c0835cd1a60ccfc8132e32a2086047db12852e6cfaf46a31e90ac98dddc993c58fdf2407808b39b8a36a56e24d863c06cf84b82b1cccd7376b7c90",
-    "otaHeaderString": "ubisys H10 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys H10 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B3B-0000-0001-02400432-m7b-h10.ota.zigbee",
     "hardwareVersionMax": 1,
     "hardwareVersionMin": 0
@@ -1364,7 +1364,7 @@
     "imageType": 31557,
     "manufacturerCode": 4338,
     "sha512": "3e6db28ad868352001057d37274d794878cd19c3f705c12cb6daecec9627a98d905c2738b187138b42f453b42d5090b9ad7c957d04e1a35161f7f5de00e63ae8",
-    "otaHeaderString": "ubisys S1-R 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys S1-R 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B45-0100-0100-02400430-ubisys-s1r-qpg6105.ota.zigbee",
     "hardwareVersionMax": 256,
     "hardwareVersionMin": 256
@@ -1377,7 +1377,7 @@
     "imageType": 31561,
     "manufacturerCode": 4338,
     "sha512": "0501b1d749df0011493b3d6a7c38706ef17a5b686e475eec6ea652329343640394e9219d7e00a1c6acd87fe0e1b5606b6a1ec9768444f2a7897df39df9faf3ca",
-    "otaHeaderString": "ubisys C4 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys C4 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B49-0100-0100-02400430-ubisys-c4-qpg6105.ota.zigbee",
     "hardwareVersionMax": 256,
     "hardwareVersionMin": 256
@@ -1390,7 +1390,7 @@
     "imageType": 31562,
     "manufacturerCode": 4338,
     "sha512": "442097a677161efd79311669d13b4d0dbd4266f5b0af3c0b9c6900c9b4c47e927d70e579386cda64af160956453f34a2a043d148a0eaebb8b56c403ccb1d75e9",
-    "otaHeaderString": "ubisys R0 2.4.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "ubisys R0 2.4.0",
     "originalUrl": "http://fwu.ubisys.de/smarthome/OTA/release/10F2-7B4A-0100-0100-02400430-ubisys-r0-qpg6105.ota.zigbee",
     "hardwareVersionMax": 256,
     "hardwareVersionMin": 256
@@ -1403,7 +1403,7 @@
     "imageType": 4113,
     "manufacturerCode": 13379,
     "sha512": "c1358d6d8cc79ab74a7d117cacb897ebc13cc68e7eb4dbdbb4614797e61ca85ab4fc522f70285b6e96f7ab1a0470c3fb3e1f3da7a68c03b57eeee0485069d115",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "",
     "originalUrl": "https://github.com/xyzroe/ZigUSB_C6/releases/download/324/ZigUSB_C6.ota",
     "modelId": "ZigUSB_C6",
     "releaseNotes": "https://github.com/xyzroe/ZigUSB_C6/releases/tag/324"
@@ -1416,7 +1416,7 @@
     "imageType": 54187,
     "manufacturerCode": 4659,
     "sha512": "6241a34dd1fb6f99fd9ad71186d769eecdc4e2f5800de50ea599abd6ff0561872343f95fc7995aa4160540a5d2f2a49a96a33d4b2f2e8082344ab1049e573a0e",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0331-191b3685-sp240-1.9.27.ota",
@@ -1426,7 +1426,7 @@
     "imageType": 817,
     "manufacturerCode": 4454,
     "sha512": "ed1744e511cdad872b6e9e513863aa23fd18b5e2a3b0c69bc69d0d185e35a61826362b57fda555eee44f0f0c05cfa750c3680c63ed62f6571e33977d5fbd1a96",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0332-191b3685-sp242-1.9.27.ota",
@@ -1436,7 +1436,7 @@
     "imageType": 818,
     "manufacturerCode": 4454,
     "sha512": "b520326f7b61b76c473f88a37f5cc57756cf643479427f9f47a60016fcd77b125a9ed4b9fe24423080d610fe2a840c54ecf99224bd40d2318f441e0057ac759c",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0333-191b3685-sp244-1.9.27.ota",
@@ -1446,7 +1446,7 @@
     "imageType": 819,
     "manufacturerCode": 4454,
     "sha512": "b610478a7e6588b9f40245eff6cd70868341e07139325058289a06bd78f40a6426eef866f42511c889da194dd8755fd33fab01ed8afc03e8c09a9c305ee9ae6c",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0334-191c3685-sp240v2-1.9.28.ota",
@@ -1456,7 +1456,7 @@
     "imageType": 820,
     "manufacturerCode": 4454,
     "sha512": "0f5c523a9da767fef3015c1db083273485df7c9c630a286a20b977530345e5b23f7b3b0fe512ecb37a420626ac39f7b0028b15d8d425defc2e1b6c86fa020484",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0335-191c3685-sp242v2-1.9.28.ota",
@@ -1466,7 +1466,7 @@
     "imageType": 821,
     "manufacturerCode": 4454,
     "sha512": "92393903c13e65063f054537aa2dd77fcf9b3fbe267f52c244d480802bb8625e6980e012105b39de15f253adfceaf8a8cd226ef6a13f66ca1b2c74e59a1dad91",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1166-0336-191c3685-sp244v2-1.9.28.ota",
@@ -1476,7 +1476,7 @@
     "imageType": 822,
     "manufacturerCode": 4454,
     "sha512": "c294996829f0b518f0e4fa66769f44d07bdae9653387be9854f2ff64b26c18cf86b0cb0b485edf9f07bdb51a0142b653daedd9f92da2283f460e3d9b2133c1d2",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "4512751-v3.12.ota",
@@ -1496,7 +1496,7 @@
     "imageType": 8199,
     "manufacturerCode": 4742,
     "sha512": "fbc751c738cf8c15e088bc5f91f9a0d039d16d09d689ede3c131ac36f2cdf63bf15f3e10cbf775a1896c57e81aeae6425abb893cb5b36e99465c1c7738ec9f39",
-    "otaHeaderString": "vers:00001201,00001200\n\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "vers:00001201,00001200\n"
   },
   {
     "fileName": "20220624200938_OTA_lumi.switch.b1nc01_0.0.0_0024_20220615_7D3656.ota",
@@ -1528,7 +1528,7 @@
     "imageType": 54193,
     "manufacturerCode": 5127,
     "sha512": "9b19db5305b3fb3f3d569690ac5d75aeb68f53841b45ab5e9226798b744d9d90bc12a6dfd3bdf6e8d30c26d3415bb208c79ed007458884c42df9487436b8c2e7",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "PMM300Z3_OTA_ENC_V7_ENC.ota",
@@ -1549,7 +1549,7 @@
     "imageType": 297,
     "manufacturerCode": 4107,
     "sha512": "3eecbdb068aeff962a430cafbcad57c8792129577eafbf409e2fc0ffb3333d04a6f492202e4d0c8362964d0bcc1a0add6f2c4b4046cfd1383ddf9e4f733abc95",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "FireAlarm_4.0.8.zigbee",
@@ -1559,7 +1559,7 @@
     "imageType": 593,
     "manufacturerCode": 4117,
     "sha512": "07bc44d6510a22f99b4ce5baf56a23aa29a8c34f213dbc5c2407fc89c6c7c3542e43082e15285aeaaa94eff4579002da8e6cc30cf35455f57dbfaf7d3db5bf2c",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "Zigbee_A19_Bulb_OTA_V56_1.00.56.ota",
@@ -1569,7 +1569,7 @@
     "imageType": 54188,
     "manufacturerCode": 5127,
     "sha512": "4481f292368d350836798cd3c97e226d111ec31e994729896890aa87dbd75a574255600cd87ad8b117a8f3a6ce1dde3634ad9210db94e453d66e50cfe4e8db08",
-    "otaHeaderString": "temp_humi_sensor\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "temp_humi_sensor"
   },
   {
     "fileName": "VZM32-SN_0.03.ota",
@@ -1580,7 +1580,7 @@
     "imageType": 259,
     "manufacturerCode": 4655,
     "sha512": "7e24a756766c6e8c6d83a14c4d875c7d149ed5c717100897883d96d06c496e9d69bf25a03c4dd2b74cef5bebaf9edd19ce4a6e23dd7e81cb6144ef3c5786bc84",
-    "otaHeaderString": "vzm32-sn_mmWave\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "vzm32-sn_mmWave"
   },
   {
     "fileName": "VZM30-SN_0.03.ota",
@@ -1590,7 +1590,7 @@
     "imageType": 272,
     "manufacturerCode": 4655,
     "sha512": "e3e4d75124c74d0595af42e9371b590098d63e86bbda515ca9a309c39894388d8fcf378969c1038d57806809464aa8a975e4f32a18d1f6836605252b58f1a9ea",
-    "otaHeaderString": "VZM30-SN_OnOff\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "otaHeaderString": "VZM30-SN_OnOff",
     "originalUrl": "https://files.inovelli.com/firmware/VZM30-SN/Beta/0.03/VZM30-SN_0.03.ota"
   }
 ]

--- a/not-in-manifest-images/not-in-manifest.json
+++ b/not-in-manifest-images/not-in-manifest.json
@@ -7,7 +7,7 @@
     "imageType": 256,
     "manufacturerCode": 4678,
     "sha512": "6b89fd90146747fde88e4896a3cb7b8600ee733679d234cb0288632c820264fcb8e5c25a79a04a4faa2114742a6f3fd37b107be6c60e927eea253fe6d8744d6a",
-    "otaHeaderString": "13-12-2022 V.0114.0114\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "13-12-2022 V.0114.0114"
   },
   {
     "fileName": "ED_HA_EMI_Norwegian_HAN_4.0.1.zigbee",
@@ -17,7 +17,7 @@
     "imageType": 832,
     "manufacturerCode": 4117,
     "sha512": "bcf8dd5ce9b622267a9999baa6df8928dd1d2511b8829a9f0a68594d9ef8b0b5f249e17828450e0845ce4d5b2d48369644c0c2327cbe65783b754061a759b6cd",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "ED_HA_Motion_Sensor_Mini-SSIG_4.0.2.zigbee",
@@ -27,7 +27,7 @@
     "imageType": 386,
     "manufacturerCode": 4117,
     "sha512": "160ebf2451f9fd6f377ba674a964e2194a173608a9f8d5cd76a9c11d5bfdebc51223d0f237f745b0db7102ae6b18f7f1436b6721240b26eb6851513ffb075b95",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "ED_Smoke_Sensor_SSIG_4.0.2.zigbee",
@@ -37,7 +37,7 @@
     "imageType": 593,
     "manufacturerCode": 4117,
     "sha512": "6ff88b27a44d0762e62d70d278313803a241ace28433135be765bb3e3fe34ec848ce71d645e28c78a88005fac03e039d507553b2fc16e1fd1b024d571a9c84c9",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "ED_Smoke_Sensor_SSIG_4.0.5.zigbee",
@@ -47,7 +47,7 @@
     "imageType": 593,
     "manufacturerCode": 4117,
     "sha512": "eb53467c3dec6ad394fe36152bb0e81f4aeaff6fd7c5c5589bf575578c8cdf6126d6219cbfdde0a1db3db7aef07124feacdf4c87cd062c9117e54f92795c5e45",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "WindowSensor_4.0.1.zigbee",
@@ -57,7 +57,7 @@
     "imageType": 576,
     "manufacturerCode": 4117,
     "sha512": "98171927e5045f7593eada86e5da1c6888b719848bc8771814e38f792d3f37f7480679e3dcb76a7ea20cb149b19512d4aebf3e105f7c1975cbd1a1ff3c3e71e9",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "20190408_EUROTRONIC_Spirit_Zigbee_0x00122C380.ota",
@@ -77,7 +77,7 @@
     "imageType": 5145,
     "manufacturerCode": 4687,
     "sha512": "e6fdd4dc6ff83d019c35b41fdba2a610363980f4c11adef86d09cbf6fdfa5889bbf01ee4c330dce9eba1eb1cc9fcf37c44447ca06321699d281ff2cd3cb44a4e",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "GL-C-002P_V20351203_20230721.ota",
@@ -87,7 +87,7 @@
     "imageType": 5145,
     "manufacturerCode": 4687,
     "sha512": "18e6d553f93a1173edb1e8aaca5023bcdb147067f5e5f776f4f207ce0a35c12910c850ef553e97fbd488e18957d5418017adce4d00d7a6007b1850f7020ea88b",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "GL-C-002P_V20551203_20240125.ota",
@@ -97,7 +97,7 @@
     "imageType": 5145,
     "manufacturerCode": 4687,
     "sha512": "d08d30e603877ef04100ba59d28ec10d6b3f3d31b9407a18517348573d39d2b67a11174e819c38752d257c3f8dd256d66a59a76225e03d4be77a6bbe8f4b3c59",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "GL-C-006P_10476801_2020401.ota",
@@ -107,7 +107,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "31b2f87344eea5bd4666918525f7382d570ab698079ed33bf40134f8ac59830c2e0d47814757e130298a50c903d4a605e914f1ef1ef68f70072daa9823bd2228",
-    "otaHeaderString": "EBL Z3LightCCT\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL Z3LightCCT"
   },
   {
     "fileName": "GL-C-006P_10576802_20240412.ota",
@@ -117,7 +117,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "28240ef0eb6b7beea8797b4d3e2acd02e3fb8967083f47a7a3597aa48306c66dcc8ad47a3a8a91189bb556445232d19f03ca3f77777421b251cf36dcf1b6b28e",
-    "otaHeaderString": "EBL Z3LightCCT\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL Z3LightCCT"
   },
   {
     "fileName": "GL-C-006P_V102.ota",
@@ -127,7 +127,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "ef83e88563221eeac951f7f6d1769891b7eb9f4df44b0acd2cdd5e473cdd9f2772fd4ec4540b5f852d93fcc14637b28567a2869fb6ea3809fcf76ea5a230572b",
-    "otaHeaderString": "EBL Z3LightCCT\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL Z3LightCCT"
   },
   {
     "fileName": "GL-C-006P_V20551203_KEY_20240227.ota",
@@ -137,7 +137,7 @@
     "imageType": 5138,
     "manufacturerCode": 4687,
     "sha512": "199c17f92fa3f238c08331e5c134630f9d725fcadfe4fcb6ef8fc55af671fe2c6fa8d20da1816948ae6927e6cfe81b732a71212662de4e6196785041769b5fb2",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "GL-C-008P_V14_OTAV4_20210114_100%.ota",
@@ -147,7 +147,7 @@
     "imageType": 0,
     "manufacturerCode": 4687,
     "sha512": "58d453955a427b1468b2e62f560f1b4b00dbb0e59a1d65e1793f2d0a960d7d2010d74900570ac1b9e0467ab5503a403aaf1ee9eed6c9db3cf34b973598a616ea",
-    "otaHeaderString": "EBL ARGBW_V_0_1\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL ARGBW_V_0_1"
   },
   {
     "fileName": "ota_t0x110e_m0x117c_v0x01000032.ota",
@@ -167,7 +167,7 @@
     "imageType": 296,
     "manufacturerCode": 4454,
     "sha512": "8d1eb89f429439fa49bab731591b58c6ad62064f45594d4d22a5b980ac807ce46696ce45bdb5025488131516c89c370c710c9dd9e4d69fc12aa80c8b423caad1",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-0129-24011511-RS_227_T-upgradeMe.ota",
@@ -177,7 +177,7 @@
     "imageType": 297,
     "manufacturerCode": 4454,
     "sha512": "5e10cdfd552f503db9ae2d01b784f0adc15a3d50b8d151cc2cd3f678e7934e14fb92ff40100345cebeda573b258a253266b9323112a31d161c77386bcc9c2ba2",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012A-24011511-RB_245_v3-upgradeMe.ota",
@@ -187,7 +187,7 @@
     "imageType": 298,
     "manufacturerCode": 4454,
     "sha512": "93f9dae79d6685494612ee27c59c3889de627396174aa78a5dd626d239c56027448e16bfbc70d16d6b0aad24a20233d20c4dc6c6c0e5ca260660cb2d090fe333",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012B-24011511-RB_249_T-upgradeMe.ota",
@@ -197,7 +197,7 @@
     "imageType": 299,
     "manufacturerCode": 4454,
     "sha512": "63dd6994410d155888f0b6d06f21b296c510bdcb0d208e59224f1d4e53bb62d90477edc7aff44ab5684f5b845adf1808eae45cfb365df18a8a15cdffef452824",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012C-24011511-RB_251_C-upgradeMe.ota",
@@ -207,7 +207,7 @@
     "imageType": 300,
     "manufacturerCode": 4454,
     "sha512": "37ce981b912a0bdaba3435127594a94ef4aa135aa5dc0750ef844abc8378f5ef5f7078a02b5bf1c5636f203db6bdc860b72a6eddd2a0a46679af206ebb5585c9",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012D-24011511-RB_266-upgradeMe.ota",
@@ -217,7 +217,7 @@
     "imageType": 301,
     "manufacturerCode": 4454,
     "sha512": "57191d741f326db3504ea8c061c17de7f55740236e9ef021f3499f229c2525a367a31bf4fee59349d7a522e6b6ab6a10d106d9133304cc03c9f01314fa4a07e0",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012E-24011511-RB_279_T-upgradeMe.ota",
@@ -227,7 +227,7 @@
     "imageType": 302,
     "manufacturerCode": 4454,
     "sha512": "1577a35a5eaae9b06bc48ed59312bf799a5fb553a1ad367c1503be89ffd6f1a919d08a3787d99fb7252c2eb4ced58d254b6372c0abd814a86698cc7d9b35bd90",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-012F-24011511-RB_286_C-upgradeMe.ota",
@@ -237,7 +237,7 @@
     "imageType": 303,
     "manufacturerCode": 4454,
     "sha512": "e98cae11a8ea9a01c7f3e6d6841f84c2e078500137ff0015d6eb5f4ec22d6efe8052284364fe4c3437482e343065be0fe75c7550394aa9585a4c98f0345741c1",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-022D-24011511-BY_266-upgradeMe.ota",
@@ -247,7 +247,7 @@
     "imageType": 557,
     "manufacturerCode": 4454,
     "sha512": "c3a22a321f042f64b0aabc016ca30ad84d4917908f98296906a8ec8af4bafb4d1f583bb81386ece0cfce36cc7ba97474bc8c4f9c7deeca2710145ba3cd3e244f",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "1166-022F-24011511-BY_286_C-upgradeMe.ota",
@@ -257,7 +257,7 @@
     "imageType": 559,
     "manufacturerCode": 4454,
     "sha512": "ff5634cc35089bf246fe0b903bbecc01824e6a995bfa84db9d3104c871f61529537dedc4174af3da2592ae8b534012d818f75343c3b8ac783d17f62a6303fb21",
-    "otaHeaderString": "Light\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Light"
   },
   {
     "fileName": "app_innr-sp240-1.7.20.ota",
@@ -267,7 +267,7 @@
     "imageType": 817,
     "manufacturerCode": 4454,
     "sha512": "6e5ab6a6ae4759b0ee46e3bd631f51914f56edd5b0cca4b151061225d1ec5b34dd0ee786e58b13ad8233286e5778042f41b20bdf4d16887403ee2579121cab69",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp240-1.7.22_UG.ota",
@@ -277,7 +277,7 @@
     "imageType": 817,
     "manufacturerCode": 4454,
     "sha512": "daa5f1dfb1664bae3ab509de256ef28f53a3579807faca3d94fd59ae5e1982665455802e959b7e87fb26af78e6f342c1070a801419c0d05af7cd2b5f32fd6d6a",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp240v2-1.7.20.ota",
@@ -287,7 +287,7 @@
     "imageType": 820,
     "manufacturerCode": 4454,
     "sha512": "a19e8cc9d9486ea20f1cf363d3c32860a4bed5682a714b66e63b35735f98591d687f2b001620550294a950b6689057f678f8a8c0b72e4f00e773bccc3e73d59e",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp240v2-1.7.22_UG.ota",
@@ -297,7 +297,7 @@
     "imageType": 820,
     "manufacturerCode": 4454,
     "sha512": "7171c301d9b0fe55a2e4a337e8e6f0c54b457548b68bb9d9c319fe4cad7af5b6543f66c84b41df154b90842b2a5b0c00b8357d1393e4e6090d43d56855189665",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp242-1.7.20.ota",
@@ -307,7 +307,7 @@
     "imageType": 818,
     "manufacturerCode": 4454,
     "sha512": "145af01a01064e34f1d6d2d2d8e5a5a748f51fbee52e644fed75c34b0474a0a23c12353ae43a1f83f6fe02e2a18401facfabb925df8317bdf83af94b46df3bf1",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp242-1.7.22_UG.ota",
@@ -317,7 +317,7 @@
     "imageType": 818,
     "manufacturerCode": 4454,
     "sha512": "01982361484aa25cd5139c796e1d0b4dac9bc6284aa67978b269440037555950079c7e0f24a6eda30b738eaa17fc56e5a6b162d13a895089b8c6fb3629946387",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp242v2-1.7.20.ota",
@@ -327,7 +327,7 @@
     "imageType": 821,
     "manufacturerCode": 4454,
     "sha512": "8c3dd4a68739b5e32779e1511f0b54d8634df5eeca10dd8f8898793d0d2ad349c180ca9ae075d9f153daada72f6c4f3d4118f1aaea655dcc57f5a323d80dcc35",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp242v2-1.7.22_UG.ota",
@@ -337,7 +337,7 @@
     "imageType": 821,
     "manufacturerCode": 4454,
     "sha512": "af6298a13f4653c16a44147163158bae2f5a19e7f1adaade5f66f3e93df8bf4eaccc4caf7abb4dd49c0c0601fdd52f8d4c7fe764725086e978ee1b61f6d587ef",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp244-1.7.20.ota",
@@ -347,7 +347,7 @@
     "imageType": 819,
     "manufacturerCode": 4454,
     "sha512": "a231abf4ed7a3f34cdc03e7d504ae7b22f9629bd84f64865ee70904f8c3b9be1145b4198ddc94474d68249a6a4bed3f9ffad09bfe553a7f970ca2c610c798958",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp244-1.7.22_UG.ota",
@@ -357,7 +357,7 @@
     "imageType": 819,
     "manufacturerCode": 4454,
     "sha512": "c0e809e7de4e8a9aca1a8dff042b802acb56978681d7cfa62571176fc596f2f5e23340673ab3954d5d4fda2707902ba0b63cc9dd2bc2aea397e6a8120e6b10d7",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp244v2-1.7.20.ota",
@@ -367,7 +367,7 @@
     "imageType": 822,
     "manufacturerCode": 4454,
     "sha512": "c0bc0fe05d920db42a826fa7379704ef71047046809d9fd8d479a41b3aa5d5a47e4883e2caa72208772a6ad32a5d137fd2a262bac106cf93a1677358ea4aa170",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "app_innr-sp244v2-1.7.22_UG.ota",
@@ -377,7 +377,7 @@
     "imageType": 822,
     "manufacturerCode": 4454,
     "sha512": "a2020ca5b93f39733fc97686e8bd333b69a490d1fa3587df9ae8c9932d83a934d4c3304f878e779c917f96fe9ffe1bb6c1aa493d3b6892726f28ade588e1695b",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "innr_controlleddevice-sp240-1.6.22.ota",
@@ -387,7 +387,7 @@
     "imageType": 817,
     "manufacturerCode": 4454,
     "sha512": "d137e8f7017c1bb02470972040bc11cb57cf5c846c86abe1703c9a78e9323d1dcf2c43466f7304eb3bd779ac7888e6f4b0f25030c24c82de038e3d7307e5cdc7",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "innr_controlleddevice-sp242-1.6.22.ota",
@@ -397,7 +397,7 @@
     "imageType": 818,
     "manufacturerCode": 4454,
     "sha512": "5127a89cc56154b83bb0f77d1287338b7c0734c3f35d8668a8162a7bb00531a89d8e9a15241d87429f0f96f7cc163fe80e5baeddb5d0d89742eb563f531cc73b",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "innr_controlleddevice-sp244-1.6.22.ota",
@@ -407,7 +407,7 @@
     "imageType": 819,
     "manufacturerCode": 4454,
     "sha512": "178498b7ad89b81792ad34df675167fcbee3c306e6bbe7336b97fe06f92b5e919d6c6b9a14788172e47deaa4422b977fed38fce7af61dd92a471886325421cc7",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "DMS300Z_OTA_ENC_V2_ENC.ota",
@@ -457,7 +457,7 @@
     "imageType": 6169,
     "manufacturerCode": 4447,
     "sha512": "33628a75e7b8ce56a0abbead156769a015889157118798f747e5324d906317453f01c4dcbcff357ff74d8f5fb019449f102d36e55f42b985347e1bd8d53eb476",
-    "otaHeaderString": "lumi.switch.n0acn2\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "lumi.switch.n0acn2"
   },
   {
     "fileName": "20220210104855_OTA_lumi.plug.mmeu01_0.0.0_0024_20220123_3B6A73.ota",
@@ -517,7 +517,7 @@
     "imageType": 0,
     "manufacturerCode": 4420,
     "sha512": "393215d51cb4c36d772323cae3731b92fa8a12367feb361afb0a1e5e55e2869f91d1221ea8d565d44b8eabedc2dcf8c8949e64cbe0101f378d8ffc3404d61648",
-    "otaHeaderString": "EBL Z3SwitchSoc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL Z3SwitchSoc"
   },
   {
     "fileName": "128b-0002-021D-700_p1771_nodon_sin_2_fw_efr32_V021D.zigbee",
@@ -527,7 +527,7 @@
     "imageType": 2,
     "manufacturerCode": 4747,
     "sha512": "2633cd834dac414cebfdb71e43a7a0e3b5f637316af3915abb917626cf84d9e37d1f08bf70b3d270b8a13ac34079c947411d147710a2a5c3257311af27a2c1f0",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0002-021F-700_nodon_sin_2_fw_efr32_V021F.zigbee",
@@ -537,7 +537,7 @@
     "imageType": 2,
     "manufacturerCode": 4747,
     "sha512": "6713ef76826e239834ee4aaaf413a8f941c764df68f5a02ac7360ea720e51ae83f46725231a2c303860006fcd9e7820c11f00c879854e49f0195f6debf4bdd5f",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0002-0300-700_nodon_sin_2_fw_efr32_V0300.zigbee",
@@ -547,7 +547,7 @@
     "imageType": 2,
     "manufacturerCode": 4747,
     "sha512": "130997beac3b0774823ab81d1703fd1ba81c70b6cf0d6b61a4afeb727d1306b9de21444a1c566af9e0e933592b8c87869714b8b6ce706db34c5ae86ab4b17c2d",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0002-0301-700_nodon_sin_2_fw_efr32_V0301.zigbee",
@@ -557,7 +557,7 @@
     "imageType": 2,
     "manufacturerCode": 4747,
     "sha512": "e9b2d70a51338c24a291201f5b7850877167e3e8c0505b84db038ddaa27865b1e03bd3ce1d618439b1c31319335a9c76fe2d6e9afcc83df1496c5f43b9c4629f",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0002-0303-700_nodon_sin_2_fw_efr32_V0303.zigbee",
@@ -567,7 +567,7 @@
     "imageType": 2,
     "manufacturerCode": 4747,
     "sha512": "39b864ea809546ba4470599eef1a821650f364a14f2ce02dd37411c2141fb15d8628d52f8b8310e50ad337a32ec450e30d2fd2645029abb369dae90145111c0b",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0005-0300-700_nodon_sin_met_fw_efr32_V0300.zigbee",
@@ -577,7 +577,7 @@
     "imageType": 5,
     "manufacturerCode": 4747,
     "sha512": "184b9a1e6e3eee2333231073c2c8dd3b2e4072219a2774bd57f59fcb09b0acbce1539fd5d9f28a808fb8ba1312c974d4cfc502e71ed6b02747d229aef78f1e9a",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0005-0301-700_nodon_sin_met_fw_efr32_V0301.zigbee",
@@ -587,7 +587,7 @@
     "imageType": 5,
     "manufacturerCode": 4747,
     "sha512": "b86a0f63d65f8ee802a2339b0b107d3dc268eb04ad1573bd73e22318965d7c0a25e8fffff2e5ad3a558358a3c7a626eb869c8db4831c558873c8a6929308d67f",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0005-0303-700_nodon_sin_met_fw_efr32_V0303.zigbee",
@@ -597,7 +597,7 @@
     "imageType": 5,
     "manufacturerCode": 4747,
     "sha512": "437c21fbcfd1d5ca853fe5cfe3b86c2705f7fda0160f536ea115ec514a0d56d7078543b0ef888c0f95ad697311bab9179cb4189cad9e85411ac53726bfcd9a33",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0006-021F-700_nodon_sin_fp_fw_efr32_V021F.zigbee",
@@ -607,7 +607,7 @@
     "imageType": 6,
     "manufacturerCode": 4747,
     "sha512": "c64adcf1118f58b3d906a7f6261e103c2d8a8d8e8c1d69e27bbe568d38c8fc44cdf0b23e0b9fd311002a5c467a07cd0fa8b2376ec8e93dc56800b19b2ad37519",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0006-0300-700_nodon_sin_fp_fw_efr32_V0300.zigbee",
@@ -617,7 +617,7 @@
     "imageType": 6,
     "manufacturerCode": 4747,
     "sha512": "9dc7ab976a2f371f2dd97559ff84abfa40e36e913775f1b2adb30c501ded716e713b88187b5a95ba3b2928170a96509a25223dc89c5cb742df2093fc04ae5d5e",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0006-0301-700_nodon_sin_fp_fw_efr32_V0301.zigbee",
@@ -627,7 +627,7 @@
     "imageType": 6,
     "manufacturerCode": 4747,
     "sha512": "393565319a21abf23627aba67c238650fa6df1a6482601b416df4e37f285d5685cb5eeae3497b834e08aff55c7dede46e9f5c5ba6436d5a463293db37d596b63",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0006-0303-700_nodon_sin_fp_fw_efr32_V0303.zigbee",
@@ -637,7 +637,7 @@
     "imageType": 6,
     "manufacturerCode": 4747,
     "sha512": "f325036d14ac78b2d5831bf7b3f53e069ab777065d07f12bf397f593b4440753dfb944884f8e96c429e246f9e5f14a7b9973cf007c07ce5ee60821cff69ce45d",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0009-021A-700_p1771_nodon_sin_rs_fw_efr32_V021A.zigbee",
@@ -647,7 +647,7 @@
     "imageType": 9,
     "manufacturerCode": 4747,
     "sha512": "30365c2d1945dd90cbeab116ccf77b2fd991fbaa82de76cf8a391469a0bee7d7075883186fb262f527a23750a89d795ced1a4bd53d8f46142b3ca000c7b77f74",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0009-021D-700_p1771_nodon_sin_rs_fw_efr32_V021D.zigbee",
@@ -657,7 +657,7 @@
     "imageType": 9,
     "manufacturerCode": 4747,
     "sha512": "04e54428ee79dba041a7d41968ebdd584bf2281c08371ecfca885189484b233244c9e331f1f77173730e0f5890721da50a3982c8d6245d7af4be9fe89ef68426",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0009-021F-700_nodon_sin_rs_fw_efr32_V021F.zigbee",
@@ -667,7 +667,7 @@
     "imageType": 9,
     "manufacturerCode": 4747,
     "sha512": "ae3dae174f703fede77d6dea1620f8d143c71d867c1ca5c8741f8f00f2f9c3149464262b6c88de62512f49b28ae9cef009222991d6ceb311481e0c70e50a84c8",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0009-0300-700_nodon_sin_rs_fw_efr32_V0300.zigbee",
@@ -677,7 +677,7 @@
     "imageType": 9,
     "manufacturerCode": 4747,
     "sha512": "89f6a3cae30018c9c6f6045ef3c475a1a12e9af0ddd9d0cfadfea122e2353b76e7e2d14a860c4292a67212d9d4315e84e9c123a47c4c694f753a88d6b1a01254",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0009-0303-700_nodon_sin_rs_fw_efr32_V0303.zigbee",
@@ -687,7 +687,7 @@
     "imageType": 9,
     "manufacturerCode": 4747,
     "sha512": "5a372c6e6d24fe307ccc9693fe14b68cff09d588f5736e4210d3ca2cb09956835781df5b1a20c5a650ab1bf61125f64e7d11b257451591e37fa1ea0d45b93f00",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-000A-021D-700_p1771_nodon_sin_1_fw_efr32_V021D.zigbee",
@@ -697,7 +697,7 @@
     "imageType": 10,
     "manufacturerCode": 4747,
     "sha512": "fb81608a3cc6e7ffd4efcfc409449d0f75bcea27e6ee1405b8f30e4c59f72346f203d97d1ecc549a2145138f494c1fcdcf65c048cb537bc420989026c97ed40c",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-000A-021F-700_nodon_sin_1_fw_efr32_V021F.zigbee",
@@ -707,7 +707,7 @@
     "imageType": 10,
     "manufacturerCode": 4747,
     "sha512": "e40fdab5bc41b290ba85b8b1da167b3d4b1698b73b7231e6122a9e8f6e17ddd15b58dbb0a81b0fc91d7098a7d0b094a25ed894d5b77fc5311da4473992e36ea5",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-000A-0300-700_nodon_sin_1_fw_efr32_V0300.zigbee",
@@ -717,7 +717,7 @@
     "imageType": 10,
     "manufacturerCode": 4747,
     "sha512": "e6ad40443575405353279e7edc0e23f4b4ded8391012f97d1e0db9d661854f6bf4cd707a969337b53e0fb7fd64ba7dbdad268d9bb3e4856c837fe47d9c06da1e",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-000A-0301-700_nodon_sin_1_fw_efr32_V0301.zigbee",
@@ -727,7 +727,7 @@
     "imageType": 10,
     "manufacturerCode": 4747,
     "sha512": "63fff10432dcdfd8b8787a347a472391c748d74b1e5f925997f52de73b35e64e1d048ef378758e55032e9b0999cd119843047695b464746d71786bdeaddaffd2",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-000A-0303-700_nodon_sin_1_fw_efr32_V0303.zigbee",
@@ -737,7 +737,7 @@
     "imageType": 10,
     "manufacturerCode": 4747,
     "sha512": "b162adae0020c2bb337aef102383338fbfe8d59d29f8fa73b8382ef6ef1e020adba1cefea7149d94733911aafadafab5921efa79e6515c8f2bf1e1e491925373",
-    "otaHeaderString": "nodon_sin_efr32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_efr32_ota"
   },
   {
     "fileName": "128b-0105-010405-700_nodon_sin_xx_met_fm_stm32_V010405.zigbee",
@@ -747,7 +747,7 @@
     "imageType": 261,
     "manufacturerCode": 4747,
     "sha512": "f2d5f9551ce46e683da7863d0ac70f3df4f0876be30268ddd86c5e095ef51d99296e94091643cee327dc33b3f3d516ef4a8cb0b5a57bfdd99a8bf365269b8d5d",
-    "otaHeaderString": "nodon_sinMet_stm32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sinMet_stm32_ota"
   },
   {
     "fileName": "128b-0106-010401-700_nodon_sin_xx_met_fm_stm32_V010401.zigbee",
@@ -757,7 +757,7 @@
     "imageType": 262,
     "manufacturerCode": 4747,
     "sha512": "d3b6ffd8d09750ceed10584649775e6aa2681085196e31bd5a1478f7ec1e8a5571244c47f9289d74cd3dad2d003307eb0083cb51f7d93afd02b916672d23baea",
-    "otaHeaderString": "nodon_sin_stm32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_stm32_ota"
   },
   {
     "fileName": "128b-0106-010405-700_nodon_sin_xx_met_fm_stm32_V010405.zigbee",
@@ -767,7 +767,7 @@
     "imageType": 262,
     "manufacturerCode": 4747,
     "sha512": "8e726566f8e6de3a0c1a86252b5330ce145b84045ccc583b6e02e92680140f7b64f81d35dcedd20958104afddbd497122770ddfb1e4b6c50cd2a5e118b052aae",
-    "otaHeaderString": "nodon_sin_stm32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_stm32_ota"
   },
   {
     "fileName": "128b-0109-010300-700_nodon_sin_rs_fm_stm32_V010300.zigbee",
@@ -777,7 +777,7 @@
     "imageType": 265,
     "manufacturerCode": 4747,
     "sha512": "866d73a17eb3eabe51f256e0a35dcc34e236522819ae220ba68cf9867a8c380a24abcfe840be135e185e1f34839e9160df6cdc41a6c9a734634945222ed38f23",
-    "otaHeaderString": "nodon_sin_stm32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_stm32_ota"
   },
   {
     "fileName": "128b-010A-10101-700_nodon_sin_1_fm_stm32_V10101.zigbee",
@@ -787,7 +787,7 @@
     "imageType": 266,
     "manufacturerCode": 4747,
     "sha512": "384ba32f433aa559534d246e498ff289bc6acb029379c816249b1e4e40dddef70da39a0e82b168a36851918c8d89f8fe245b15031faa860ff2175a077c2e364b",
-    "otaHeaderString": "nodon_sin_stm32_ota\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "nodon_sin_stm32_ota"
   },
   {
     "fileName": "007B-0141-00002867-good_image_PL_1_3_43.zigbee",
@@ -797,7 +797,7 @@
     "imageType": 321,
     "manufacturerCode": 123,
     "sha512": "b27714b307f6e6ac8fb1c3dacf3ebda25afd7c36fe7cea72637aedd90c1164807035d51e00743069ef4bd165787feab4ce3c678808dddf109e5e76847b695843",
-    "otaHeaderString": "\ngood_image\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "\ngood_image"
   },
   {
     "fileName": "1542704530003_RDS2017007_E11-N1EA_V0.0.49_20181026_release.ota",
@@ -807,7 +807,7 @@
     "imageType": 1004,
     "manufacturerCode": 4448,
     "sha512": "4d4d20b3e162db7fc250f90c6220181d221b36f89a32ef4ad1d9081a04538a1c36c55a23da273b74822e968b2f6a82c75a62fb6df866ac53f80a68b597556420",
-    "otaHeaderString": "EBL rgb_lamp\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL rgb_lamp"
   },
   {
     "fileName": "1554860326863_RDS2018021_E1G-G8E_V10_20190405_release.ota",
@@ -817,7 +817,7 @@
     "imageType": 5,
     "manufacturerCode": 4448,
     "sha512": "24e5db1ad8edf50489ff7ad4e683fd3f1c339b890df2f5a95e128df07c65305d19404e4363dd9882f6d2a0629e0dc2ca48e0016782645ee9c543e8250a713b39",
-    "otaHeaderString": "EBL RGB_LampTape\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL RGB_LampTape"
   },
   {
     "fileName": "snzb-06p_v1.0.5.ota",
@@ -827,7 +827,7 @@
     "imageType": 2060,
     "manufacturerCode": 4742,
     "sha512": "fdcd4e238b25a971d79746a0305e185567e027c3ba08ed42ac7ca003601c25ccce497fd1f8e6ede1e0e7b058768bc2daf3ebc985174fc6265a9df4acc4f81467",
-    "otaHeaderString": "vers: ZigBee:00001005\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "vers: ZigBee:00001005"
   },
   {
     "fileName": "trvzb_v1.1.1.ota",
@@ -837,7 +837,7 @@
     "imageType": 8199,
     "manufacturerCode": 4742,
     "sha512": "b132f02055dffcbf55ccf94f164f1cc1fedb350be4755b56a8da1c3c51ae6814bba3e8650376ce76a0783394eae1315e912deba917efd4f36557c92068b437ef",
-    "otaHeaderString": "vers:00001101,00001101\n\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "vers:00001101,00001101\n"
   },
   {
     "fileName": "trvzb_v1.1.5.ota",
@@ -847,7 +847,7 @@
     "imageType": 8199,
     "manufacturerCode": 4742,
     "sha512": "648ae2ebb866d0d0a2e593b34570943d7fd8596a417597eb4a1966d7caa5bbf60611659ee211aa0d0788d79fbd58627f4e9ac87a62c97912c6a83652e90ef734",
-    "otaHeaderString": "vers:00001105,00001106\n\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "vers:00001105,00001106\n"
   },
   {
     "fileName": "zbswv_v1.0.3.ota",
@@ -857,7 +857,7 @@
     "imageType": 8202,
     "manufacturerCode": 4742,
     "sha512": "2108581ad91e16464c6abc4919808899abadcab566ad7f43ad3bf8d4e0ac6734dfbf2b82fcfdaf098570e7501a6e03a8fc1036f9f91c1b3e8911b37be350de1c",
-    "otaHeaderString": "ota-file-test\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "ota-file-test"
   },
   {
     "fileName": "wb_msw4_mgm_061.ota",
@@ -867,7 +867,7 @@
     "imageType": 13,
     "manufacturerCode": 26214,
     "sha512": "f68ec119f2a779f10446847d7fe0edcebf44f19bd5e452631aacba295bfcae4881f0a7be934c03e864c3262f26ede6f527f299a4157c6997f94db2fb925a5709",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "zb_wb_msw4_005.ota",
@@ -877,7 +877,7 @@
     "imageType": 13,
     "manufacturerCode": 26214,
     "sha512": "bf3155e470014ebd73b132102e26b460629030b314d00fe78ddd0c3ca157409e9c0e1d23aa93e34454391688f6294719be964627969cefcfc48efbb3c1dfdc96",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "zb_wb_msw4_mg21_062.ota",
@@ -887,7 +887,7 @@
     "imageType": 15,
     "manufacturerCode": 26214,
     "sha512": "0f5b47092c2df550270460d9e446563da1bb72fd841747c9b738f6b75de6cebecdc92aa7aa3be2c814cbea9aea624c5f9d0f4dbdbc150f3b569c25d764629d02",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "zb_wb_msw4_mgm21_062.ota",
@@ -897,7 +897,7 @@
     "imageType": 13,
     "manufacturerCode": 26214,
     "sha512": "9d47a8eaaaf41c8fa03abafbcb407450a6ca3ff25006cfa33e1c7d3b663ec4b0472c4c2622aa246152488ef5854c293d0932712bbe364bf8a7ff5a72c3b74c30",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "zb_wb_msw_31_692_0_058.ota",
@@ -907,7 +907,7 @@
     "imageType": 1,
     "manufacturerCode": 26214,
     "sha512": "40435559fe1aa4be0fa3cfffdb46a010a28a7776e6c73e200f43560d18eeb3f0fd594855781f39800b05b668161dcc2342d65f11e4e80642cbe814a27fa4bab7",
-    "otaHeaderString": "EBL zb_wb_msw\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL zb_wb_msw"
   },
   {
     "fileName": "zb_wb_msw_31_692_A_058.ota",
@@ -917,7 +917,7 @@
     "imageType": 2,
     "manufacturerCode": 26214,
     "sha512": "0dd1d20605de46ed5c068cbb07a4c31cc11d87042717083887d1b0abc8fbdc0c33928286669b206d7cf79228832b6410f488c7a316250a1b0fa144749b40328b",
-    "otaHeaderString": "EBL zb_wb_msw\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL zb_wb_msw"
   },
   {
     "fileName": "1141-0203-10023001-z03mmc.zigbee",
@@ -927,7 +927,7 @@
     "imageType": 515,
     "manufacturerCode": 4417,
     "sha512": "b0ba8552a907b77a0158d91c618f27549981ff9845fa5f69ec7ca490453efbd4b029f3347ec5d770a17a0d7990cda31a66898f4268dc260478aea41220294ee8",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "1141-0203-10043001-z03mmc.zigbee",
@@ -937,7 +937,7 @@
     "imageType": 515,
     "manufacturerCode": 4417,
     "sha512": "54c954123b43a4c41376f57e4ab1869dca2698c178a82251725174e976da9107ebb7ddf632aa8223ba49a6b5e3dba7a878db7dcf801dcc5c3b888c2d5c1378a5",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "1141-0203-10053001-z03mmc.zigbee",
@@ -947,7 +947,7 @@
     "imageType": 515,
     "manufacturerCode": 4417,
     "sha512": "3c62be5c6558ea918932fe52fcdc0c622d8fdedb9fd3d8e62fb1c430c4f95f64d710388efe3e565bda4403e18f624f586e8fc2a3b3570b00687470faf58d807e",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "1141-0203-10063001-z03mmc.zigbee",
@@ -957,7 +957,7 @@
     "imageType": 515,
     "manufacturerCode": 4417,
     "sha512": "9dc307f05613bd43384744901eb4aea7bb5cfa9f4385ee2693b46afd1d0f5dc5eca6e5ce217a04aae9d1ba89799b389a6f9b01ca7779aed80ece355c91c92d90",
-    "otaHeaderString": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": ""
   },
   {
     "fileName": "1654157434-oem_zg_tl8258_plug_OTA_1.0.13.bin",
@@ -967,7 +967,7 @@
     "imageType": 54179,
     "manufacturerCode": 4417,
     "sha512": "97ea8413e8ab662f2bebf3b013b3030754cbc2c0744b91b14741fff17a2d8d99e7088aa22a3b6e43b3595ccd65433f96d32516fc057fddcc13a816c921af8c97",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "nas_wr01b_plug_OTA_1.0.10.bin",
@@ -977,7 +977,7 @@
     "imageType": 54179,
     "manufacturerCode": 4417,
     "sha512": "3c70afc8d2488c22b7a99ab53cf0250b6aa12b2eb5d703cb819620c07dc10dbdd7fe8e3a2ef63cdaedd9b97d502c71c2c2c199fb05121f977b87a86e8bbe91bb",
-    "otaHeaderString": "Telink OTA Sample Usage\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "1600167449-si32_zg_uart_connect_sleep_ZS5_ty_OTA_1.1.5.bin",
@@ -987,6 +987,6 @@
     "imageType": 5634,
     "manufacturerCode": 4098,
     "sha512": "aefc41c93329f36f87ac955a1b2f15706c8371e9ad275234b6519c84a76c642037fc63f71236829c764ed5898dc7aedc27736797faf1bc1dfeec0e93a824ed43",
-    "otaHeaderString": "EBL sdk_route\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "otaHeaderString": "EBL sdk_route"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -54,5 +54,11 @@
         "@vitest/coverage-v8": "^3.1.1",
         "typescript": "^5.8.3",
         "vitest": "^3.1.1"
+    },
+    "pnpm": {
+        "onlyBuiltDependencies": [
+            "@biomejs/biome",
+            "esbuild"
+        ]
     }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -358,7 +358,7 @@ export function addImageToPrev(
         imageType: parsedImage.imageType,
         manufacturerCode: parsedImage.manufacturerCode,
         sha512: computeSHA512(firmwareBuffer),
-        otaHeaderString: parsedImage.otaHeaderString,
+        otaHeaderString: parsedImage.otaHeaderString.replaceAll("\u0000", ""),
         ...extraMetas,
     });
 }
@@ -431,7 +431,7 @@ export function addImageToBase(
         imageType: parsedImage.imageType,
         manufacturerCode: parsedImage.manufacturerCode,
         sha512: computeSHA512(firmwareBuffer),
-        otaHeaderString: parsedImage.otaHeaderString,
+        otaHeaderString: parsedImage.otaHeaderString.replaceAll("\u0000", ""),
         ...extraMetas,
     });
 }

--- a/src/ghw_identify_stacks.ts
+++ b/src/ghw_identify_stacks.ts
@@ -1,0 +1,221 @@
+import type CoreApi from "@actions/core";
+import type {Context} from "@actions/github/lib/context";
+import type {Octokit} from "@octokit/rest";
+
+import {readFileSync, writeFileSync} from "node:fs";
+import {join} from "node:path";
+
+import {BASE_INDEX_MANIFEST_FILENAME, BASE_REPO_URL, REPO_BRANCH, UPGRADE_FILE_IDENTIFIER, parseImageHeader, readManifest} from "./common.js";
+
+enum ZigBeeStackVersion {
+    ZigBee2006 = 0x0000,
+    ZigBee2007 = 0x0001,
+    ZigBeePro = 0x0002,
+    ZigBeeIP = 0x0003,
+}
+
+type FirmwareStack = {
+    url: string;
+    modelId?: string;
+    stack:
+        | "EmberZNet" // Silabs https://github.com/SiliconLabs/simplicity_sdk or https://github.com/SiliconLabs/gecko_sdk
+        | "zStack" // TI https://github.com/TexasInstruments/simplelink-lowpower-f2-sdk
+        | "Telink" // https://github.com/telink-semi/telink_zigbee_sdk
+        | "NXP"
+        | "BitCloud" // Microchip https://github.com/Microchip-MPLAB-Harmony/wireless_zigbee
+        | "ZBOSS" // https://github.com/TexasInstruments/simplelink-lowpower-f3-sdk or https://github.com/nrfconnect/ncs-zigbee/ or https://github.com/nrfconnect/ncs-zigbee-r22/ or https://github.com/espressif/esp-zigbee-sdk
+        | "Unknown";
+    stackDetails: string;
+    /** @see ZigBeeStackVersion */
+    zigbeeStackVersion: string;
+};
+
+type OtaSubElement = {
+    tagId: number;
+    length: number;
+    data: Buffer;
+};
+
+const INDEX_STACKINFO_MANIFEST_FILENAME = "index-stackinfo.json";
+const SI_GBL_HEADER_TAG = Buffer.from([0xeb, 0x17, 0xa6, 0x03]);
+const SI_EBL_TAG_HEADER = 0x0;
+const SI_EBL_IMAGE_SIGNATURE = 0xe350;
+const SI_EBL_TAG_ENC_HEADER = 0xfb05;
+const TI_OAD_IMG_ID_VAL_CC26X2R1 = Buffer.from("CC26x2R1", "utf8");
+const TI_OAD_IMG_ID_VAL_CC13X2R1 = Buffer.from("CC13x2R1", "utf8");
+const TI_OAD_IMG_ID_VAL_CC13X4 = Buffer.from("CC13x4  ", "utf8");
+const TI_OAD_IMG_ID_VAL_CC26X3 = Buffer.from("CC26x3  ", "utf8");
+const TI_OAD_IMG_ID_VAL_CC26X4 = Buffer.from("CC26x4  ", "utf8");
+const TI_OAD_IMG_ID_VAL_OADIMG = Buffer.from("OAD IMG ", "utf8");
+const TI_OAD_IMG_ID_VAL_CC23X0R2 = Buffer.from("CC23x0R2", "utf8");
+const TL_START_UP_FLAG_WHOLE = 0x544c4e4b; // Buffer.from('KNLT', 'utf8');
+const TL_SR_TAG = Buffer.from("TLSR", "utf8");
+
+function parseSubElements(otaData: Buffer, totalImageSize: number): OtaSubElement[] {
+    let position = 0;
+    const elements: OtaSubElement[] = [];
+
+    try {
+        while (position < totalImageSize) {
+            const tagId = otaData.readUInt16LE(position);
+            position += 2;
+            const length = otaData.readUInt32LE(position);
+            position += 4;
+            const data = otaData.subarray(position, position + length);
+            position += length;
+
+            if (data.byteLength !== length) {
+                throw new Error("Invalid data byte length");
+            }
+
+            elements.push({tagId, length, data});
+        }
+    } catch {
+        /* ignore */
+    }
+
+    return elements;
+}
+
+export function identifyStacks(github: Octokit, core: typeof CoreApi, context: Context): void {
+    try {
+        const firmwareList: FirmwareStack[] = [];
+        const baseManifest = readManifest(BASE_INDEX_MANIFEST_FILENAME);
+
+        for (const meta of baseManifest) {
+            const filePath = decodeURIComponent(meta.url.replace(BASE_REPO_URL + REPO_BRANCH, ""));
+            const fileBuf = readFileSync(join(".", filePath));
+            const otaImage = fileBuf.subarray(fileBuf.indexOf(UPGRADE_FILE_IDENTIFIER));
+            const header = parseImageHeader(otaImage);
+            const otaData = otaImage.subarray(header.otaHeaderLength);
+            let stack: FirmwareStack["stack"] = "Unknown";
+            let stackDetails = "";
+
+            for (const {tagId, data} of parseSubElements(otaData, header.totalImageSize)) {
+                if (data.indexOf(SI_GBL_HEADER_TAG) === 0) {
+                    stack = "EmberZNet";
+                    stackDetails = "GBL";
+
+                    break;
+                }
+
+                if (data.readUInt16BE(0) === SI_EBL_TAG_HEADER && data.readUInt16BE(6) === SI_EBL_IMAGE_SIGNATURE) {
+                    stack = "EmberZNet";
+                    stackDetails = "EBL";
+
+                    break;
+                }
+
+                if (data.readUInt16BE(0) === SI_EBL_TAG_ENC_HEADER) {
+                    stack = "EmberZNet";
+                    stackDetails = "EBL ENC";
+
+                    break;
+                }
+
+                if (data.indexOf(TI_OAD_IMG_ID_VAL_CC26X2R1) === 0) {
+                    stack = "zStack";
+                    stackDetails = "CC26x2R1";
+
+                    break;
+                }
+
+                if (data.indexOf(TI_OAD_IMG_ID_VAL_CC13X2R1) === 0) {
+                    stack = "zStack";
+                    stackDetails = "CC13x2R1";
+
+                    break;
+                }
+
+                if (data.indexOf(TI_OAD_IMG_ID_VAL_CC13X4) === 0) {
+                    stack = "zStack";
+                    stackDetails = "CC13x4";
+
+                    break;
+                }
+
+                if (data.indexOf(TI_OAD_IMG_ID_VAL_CC26X3) === 0) {
+                    stack = "zStack";
+                    stackDetails = "CC26x3";
+
+                    break;
+                }
+
+                if (data.indexOf(TI_OAD_IMG_ID_VAL_CC26X4) === 0) {
+                    stack = "zStack";
+                    stackDetails = "CC26x4";
+
+                    break;
+                }
+
+                if (data.indexOf(TI_OAD_IMG_ID_VAL_OADIMG) === 0) {
+                    stack = "zStack";
+                    stackDetails = "OAD IMG";
+
+                    break;
+                }
+
+                if (data.indexOf(TI_OAD_IMG_ID_VAL_CC23X0R2) === 0) {
+                    stack = "zStack";
+                    stackDetails = "CC23x0R2";
+
+                    break;
+                }
+
+                if (data.byteLength >= 12 && data.readUInt32LE(8) === TL_START_UP_FLAG_WHOLE) {
+                    stack = "Telink";
+                    const tlsrIndex = data.indexOf(TL_SR_TAG);
+
+                    if (tlsrIndex !== -1) {
+                        stackDetails = data.subarray(tlsrIndex, tlsrIndex + 8).toString("utf8");
+                    }
+
+                    break;
+                }
+
+                if (
+                    data.indexOf(Buffer.from("nRF", "utf8")) !== -1 ||
+                    data.indexOf(Buffer.from("nrf5", "utf8")) !== -1 ||
+                    data.indexOf(Buffer.from("nrf_", "utf8")) !== -1
+                ) {
+                    stack = "ZBOSS";
+                    stackDetails = "Nordic (fuzzy matching)";
+                    break;
+                }
+
+                core.info(`UNKNOWN ${filePath} tagId=${tagId} firstBytes=${data.subarray(0, 16).toString("hex")}`);
+            }
+
+            if (stack === "Unknown") {
+                if (header.otaHeaderString.includes("Telink")) {
+                    stack = "Telink";
+                    stackDetails = "(fallback matching)";
+                } else if (header.otaHeaderString.includes("GBL")) {
+                    stack = "EmberZNet";
+                    stackDetails = "GBL (fallback matching)";
+                } else if (header.otaHeaderString.includes("EBL")) {
+                    stack = "EmberZNet";
+                    stackDetails = "EBL (fallback matching)";
+                } /* else if () {
+                    // stack = 'zStack';
+                }*/
+            }
+
+            firmwareList.push({
+                url: meta.url,
+                // modelId: meta.modelId,
+                stack,
+                stackDetails,
+                zigbeeStackVersion: ZigBeeStackVersion[header.zigbeeStackVersion],
+            });
+        }
+
+        writeFileSync(INDEX_STACKINFO_MANIFEST_FILENAME, JSON.stringify(firmwareList, undefined, 2), "utf8");
+    } catch (error) {
+        core.error((error as Error).message);
+        core.debug((error as Error).stack!);
+    }
+}
+
+// // @ts-expect-error run locally
+// identifyStacks({}, console, {});

--- a/src/ghw_reprocess_all_images.ts
+++ b/src/ghw_reprocess_all_images.ts
@@ -397,10 +397,12 @@ export async function reProcessAllImages(
 
 // To run locally uncomment below and run with `npx tsx src/ghw_reprocess_all_images.ts`
 // const core = {
-//     info: (msg) => console.log(msg),
-//     warning: (msg) => console.log(msg),
-//     error: (msg) => console.error(msg),
-//     startGroup: () => {},
-//     endGroup: () => {},
+//     debug: console.debug,
+//     info: console.info,
+//     warning: console.warn,
+//     error: console.error,
+//     startGroup: console.group,
+//     endGroup: console.groupEnd,
 // }
-// checkImagesAgainstManifests(null, core, null, false);
+// // @ts-expect-error run locally
+// checkImagesAgainstManifests({}, core, {}, false);

--- a/src/ghw_reprocess_all_images.ts
+++ b/src/ghw_reprocess_all_images.ts
@@ -275,7 +275,7 @@ function checkImagesAgainstManifests(github: Octokit, core: typeof CoreApi, cont
                                     imageType: parsedImage.imageType,
                                     manufacturerCode: parsedImage.manufacturerCode,
                                     sha512: computeSHA512(firmwareBuffer),
-                                    otaHeaderString: parsedImage.otaHeaderString,
+                                    otaHeaderString: parsedImage.otaHeaderString.replaceAll("\u0000", ""),
                                 });
                             } catch (error) {
                                 core.error(`Removing ${firmwareFilePath}: ${error}`);
@@ -307,7 +307,7 @@ function checkImagesAgainstManifests(github: Octokit, core: typeof CoreApi, cont
                                         imageType: parsedImage.imageType,
                                         manufacturerCode: parsedImage.manufacturerCode,
                                         sha512: computeSHA512(firmwareBuffer),
-                                        otaHeaderString: parsedImage.otaHeaderString,
+                                        otaHeaderString: parsedImage.otaHeaderString.replaceAll("\u0000", ""),
                                         ...extraMetas,
                                     });
                                 }

--- a/src/print_ota_image_header.ts
+++ b/src/print_ota_image_header.ts
@@ -1,5 +1,7 @@
 import {readFileSync} from "node:fs";
 
-import {parseImageHeader} from "./common.js";
+import {UPGRADE_FILE_IDENTIFIER, parseImageHeader} from "./common.js";
 
-console.log(parseImageHeader(readFileSync(process.argv[2])));
+const firmwareBuffer = readFileSync(process.argv[2]);
+
+console.log(parseImageHeader(firmwareBuffer.subarray(firmwareBuffer.indexOf(UPGRADE_FILE_IDENTIFIER))));

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -192,7 +192,7 @@ export const IMAGE_INVALID_METAS = {
  * - imageType: 2,
  * - fileVersion: 6,
  * - zigbeeStackVersion: 2,
- * - otaHeaderString: 'Jasco 45856 image\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+ * - otaHeaderString: 'Jasco 45856 image',
  * - totalImageSize: 162302
  */
 export const IMAGE_TAR_METAS = {
@@ -204,7 +204,7 @@ export const IMAGE_TAR_METAS = {
     imageType: 2,
     manufacturerCode: 4388,
     sha512: "3306332e001eab9d71c9360089d450ea21e2c08bac957b523643c042707887e85db0c510f3480bdbcfcfe2398eeaad88d455f346f1e07841e1d690d8c16dc211",
-    otaHeaderString: "Jasco 45856 image\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+    otaHeaderString: "Jasco 45856 image",
 };
 
 export const getImageOriginalDirPath = (imageName: string): string => {


### PR DESCRIPTION
Purely for dev usage.
Knowing the stacks running on certain devices when debugging can be pretty useful sometimes. This is limited by the availability of OTA firmware files of course, and the "possibility" to identify stacks from them, but it still provides a decent database.
_Kept as a separate JSON to not crowd the manifests._
I've looked up a few of the magic numbers that can be used to identify stacks, but still some left to do (closed source makes that harder...).
Set to run with autodl workflow.

Also cleaned up null chars from manifests (and generating code).