### PR TITLE
Manual fixes for Hue OTAs

### DIFF
--- a/index.json
+++ b/index.json
@@ -659,7 +659,8 @@
     "sha512": "4d15669f586c39da05fdfa95506fa085e297e177e5f2e962ce5f8ec2788f1d4488f880c35c2f2a1e0279ffe66272c99d27ca6da5d80512b88fcf50a574647a64",
     "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0110/77cabadf-422e-4b65-a971-b40f6422ca6f/100B-0110-01002602-ConfLight-Lamps-EFR32MG13.zigbee",
-    "minFileVersion": 16778240
+    "minFileVersion": 16778240,
+    "maxFileVersion": 16786945
   },
   {
     "fileName": "100B-0111-01001D00-ConfLight-ModuLum-EFR32MG13.zigbee",
@@ -681,7 +682,8 @@
     "manufacturerCode": 4107,
     "sha512": "5e7c52ee30fcdca12b875499923ede2078efec650cbbb0a1267874fc88acde456e439b53e6abc69501ed058d6abfeb031f7dec6df888c79b44fc6a7a13927d7b",
     "otaHeaderString": "",
-    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0112/fd7eef13-74d9-4920-8315-45adcf652102/100B-0112-01002902-ConfLightBLE-Lamps-EFR32MG13.zigbee"
+    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0112/fd7eef13-74d9-4920-8315-45adcf652102/100B-0112-01002902-ConfLightBLE-Lamps-EFR32MG13.zigbee",
+    "maxFileVersion": 16787713
   },
   {
     "fileName": "100B-0114-01001200-ConfLightBLE-Lamps-EFR32MG21.zigbee",
@@ -731,7 +733,8 @@
     "sha512": "a4dec4e9d3bb2561218cf370fb9306d85f00464f908a029cf4dc779050fe03fabac041dafe257d6088698c6854dc4326a446b017ef183a06037160bb81e5af33",
     "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0114/b9ca4597-f893-4658-99ad-ed61050ab741/100B-0114-01002502-ConfLightBLE-Lamps-EFR32MG21.zigbee",
-    "minFileVersion": 16782084
+    "minFileVersion": 16782084,
+    "maxFileVersion": 16786689
   },
   {
     "fileName": "100B-0115-01001402-SmartPlug-EFR32MG13.zigbee",
@@ -742,7 +745,8 @@
     "manufacturerCode": 4107,
     "sha512": "d2b85f5575c9e5f93966ae3d918a9ace2c725549c7e55c58993217c7bc131ceee20a717912c9b32e697ea840f2c747afdd0a5861b581c4d6bc30416ac26d8360",
     "otaHeaderString": "",
-    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0115/84e91e20-7715-4bd0-9a41-2f6dcca94be8/100B-0115-01001402-SmartPlug-EFR32MG13.zigbee"
+    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0115/84e91e20-7715-4bd0-9a41-2f6dcca94be8/100B-0115-01001402-SmartPlug-EFR32MG13.zigbee",
+    "maxFileVersion": 16782337
   },
   {
     "fileName": "100B-0116-02001300-Switch-EFR32MG13.zigbee",
@@ -890,7 +894,8 @@
     "sha512": "82ba5d9ce6d0b590e85458b796a1c8d1375d2ac1a24432bc83504f54bf56ca62f96b27b27fe4f867d1ade6c8813045118078aa4b98a6532f8f5a2aeeeaa23c16",
     "otaHeaderString": "",
     "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011A/0aafab7f-56c0-4c7b-b0f8-19cfe1f02602/100B-011A-01000F04-SmartPlug-EFR32MG21.zigbee",
-    "minFileVersion": 16778500
+    "minFileVersion": 16778500,
+    "maxFileVersion": 16781059
   },
   {
     "fileName": "100B-011B-02004D23-Sensor-EFR32MG22.zigbee",
@@ -923,7 +928,8 @@
     "manufacturerCode": 4107,
     "sha512": "ca172fda58aac17c731cb55fdf4c4856596917725d1a127c77d64e344b68dbafc063984772e408f94b4dfd8b4a815dc259e48234e55314124b8ca75f4c457c13",
     "otaHeaderString": "",
-    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011D/6f9c541e-b1d2-42c2-8098-fc2ce7017cfc/100B-011D-01002504-ConfLight-ModuLumV2-EFR32MG13.zigbee"
+    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011D/6f9c541e-b1d2-42c2-8098-fc2ce7017cfc/100B-011D-01002504-ConfLight-ModuLumV2-EFR32MG13.zigbee",
+    "maxFileVersion": 16786691
   },
   {
     "fileName": "100B-011E-01002404-ConfLight-PortableV2-EFR32MG13.zigbee",
@@ -934,7 +940,8 @@
     "manufacturerCode": 4107,
     "sha512": "77c8e3a4953fa7c1b376f63968df11f7b053a55c895d178cbfaecc5b394684f734fe2f9188abd1afcff7eb96da0daea0803b88397b311a198817bda944543ecf",
     "otaHeaderString": "",
-    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011E/42d2db88-6252-4a0f-8c10-ab3fe9a0e8b0/100B-011E-01002404-ConfLight-PortableV2-EFR32MG13.zigbee"
+    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011E/42d2db88-6252-4a0f-8c10-ab3fe9a0e8b0/100B-011E-01002404-ConfLight-PortableV2-EFR32MG13.zigbee",
+    "maxFileVersion": 16786435
   },
   {
     "fileName": "100B-011F-01002402-ConfLightBLE-ModuLumV3-EFR32MG21.zigbee",
@@ -945,7 +952,8 @@
     "manufacturerCode": 4107,
     "sha512": "8ec63076c58fb6c3870234aec98ff86ea7043bd25601e155c69f7e864f6bf858e950c76b5bad77386025a79a4fa9a126d87db7ca61e707a0f605fff06b212b3d",
     "otaHeaderString": "",
-    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011F/f88abe86-a753-417f-b6e9-772a7a15e84a/100B-011F-01002402-ConfLightBLE-ModuLumV3-EFR32MG21.zigbee"
+    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_011F/f88abe86-a753-417f-b6e9-772a7a15e84a/100B-011F-01002402-ConfLightBLE-ModuLumV3-EFR32MG21.zigbee",
+    "maxFileVersion": 16786433
   },
   {
     "fileName": "100B-0121-02004D27-Switch-EFR32MG22-40xf.zigbee",
@@ -978,7 +986,7 @@
     "manufacturerCode": 4107,
     "sha512": "a2a0076275a1dcdb94a9bea8c1591209f31f76fe847d5fd46456dad63247d0c302e438776c179dcc86f93471b3965e884f3455c06c332313fdc408df71a58c11",
     "otaHeaderString": "",
-    "originalUrl": "https://firmware.meethue.com/storage/100b-125/33571585/17803020-a40e-4015-b9e3-3454e43998bb/100B-0125-02004301-ContactSensor-EFR32MG22.zigbee",
+    "originalUrl": "https://otau.meethue.com/storage/ZGB_100B_0125/9d8ae429-ad80-434b-8e18-cc969b2f34d5/100B-0125-02004301-ContactSensor-EFR32MG22.zigbee",
     "maxFileVersion": 33571584
   },
   {


### PR DESCRIPTION
Follow-up to:
- https://github.com/Koenkk/zigbee-OTA/pull/811

This adds min/max file versions for the added Hue OTAs.

---

Semi related, but the order for the metadata keys does not seem to be fixed (so it's not always the same).
My scripts always assumed the following order for the OTA metadata. However, some entries have the `originalUrl` in a different place (after `fileSize`).
Technically, it doesn't matter of course and I've updated my scripts to keep whatever order is present, but maybe the repo scripts should be updated to consistently follow one order?

Order I assumed to be standard (and it seems to be be that way for most entries):
- `fileName`
- `fileVersion`
- `fileVersion`
- `fileSize`
- `url`
- `imageType`
- `manufacturerCode`
- `sha512`
- `otaHeaderString`
- `originalUrl` (optional)
- `maxFileVersion` (optional)
- `minFileVersion` (optional)