### PR TITLE
Add `modelId` for Bosch devices that didn't had it yet

### DIFF
--- a/index.json
+++ b/index.json
@@ -7720,7 +7720,8 @@
     "imageType": 12300,
     "manufacturerCode": 4617,
     "sha512": "639bc773d0b7d7326d594c530ef3d711a4f31cf392df88f32c051ef145f4bd3b151805bdc77234631e9f7d4c7454ba4b7c0335d0a2873a3a7ef60199528b44a6",
-    "otaHeaderString": "MM_DIMMER"
+    "otaHeaderString": "MM_DIMMER",
+    "modelId": "RBSH-MMD-ZB-EU"
   },
   {
     "fileName": "MICROMODULE_RELAY_0x210C6A30_PROD.fw",
@@ -7730,7 +7731,8 @@
     "imageType": 12301,
     "manufacturerCode": 4617,
     "sha512": "efe3066a98b71f067ad9840172b073690c136a7292774e72a3a41fcb403c423aee7e27b71e07538d148123d3d89257e154273e5609b44cb304035dfe6a0611bc",
-    "otaHeaderString": "MM_RELAY"
+    "otaHeaderString": "MM_RELAY",
+    "modelId": "RBSH-MMR-ZB-EU"
   },
   {
     "fileName": "OUTDOOR_SIREN_421095264.fw",
@@ -7740,7 +7742,8 @@
     "imageType": 12293,
     "manufacturerCode": 4617,
     "sha512": "dce1d9ea74b8684025584182cefe76abbb65f14f0e1fb4d6e772fea52810bab1bfaada3c01a0494c413257f17b44633efec8da606b44b1372490e35391a7992a",
-    "otaHeaderString": "ZB_C667_OutdoorSiren_Signed"
+    "otaHeaderString": "ZB_C667_OutdoorSiren_Signed",
+    "modelId": "RBSH-OS-ZB-EU"
   },
   {
     "fileName": "PLUG_COMPACT_FR_0x2A006A30_PROD.fw",
@@ -7750,7 +7753,8 @@
     "imageType": 12291,
     "manufacturerCode": 4617,
     "sha512": "3a9e32be86c91ebef83c08f0b8216fe9fbb254392359c8bdecbd87f8cc9c30d8eae2e256fd74817f3a6b915c3af7678b306cae58d1882d7b037d83195dd5fe64",
-    "otaHeaderString": "PLUG_FR"
+    "otaHeaderString": "PLUG_FR",
+    "modelId": "RBSH-SP-ZB-FR"
   },
   {
     "fileName": "PLUG_COMPACT_GB_0x2A006A30_PROD.fw",
@@ -7760,7 +7764,8 @@
     "imageType": 12292,
     "manufacturerCode": 4617,
     "sha512": "3d6bcd7ed27afe5ec9f19f51567fc868361b9f868a044c3e1c58fbdde68e24691c2bfe3c77cef7632b20c60731f76837aeda26540840c9daca437f1aa89a4c62",
-    "otaHeaderString": "PLUG_GB"
+    "otaHeaderString": "PLUG_GB",
+    "modelId": "RBSH-SP-ZB-GB"
   },
   {
     "fileName": "SWD2_0x11191514_PROD.fw",
@@ -7770,7 +7775,8 @@
     "imageType": 12295,
     "manufacturerCode": 4617,
     "sha512": "a3fc0d8b0a0948ba589f410b97669b4e93e11edde4cc76e09864b11e778f7c0ea3ef8abf34cec89b83d9dc8c408babd6bdd7102ac8e51a8bc3b1f11d034b458a",
-    "otaHeaderString": "RBSH-SWD-ZB"
+    "otaHeaderString": "RBSH-SWD-ZB",
+    "modelId": "RBSH-SWD-ZB"
   },
   {
     "fileName": "WLS_553805664.fw",
@@ -7780,7 +7786,8 @@
     "imageType": 12289,
     "manufacturerCode": 4617,
     "sha512": "234de561fcbe5ec07593fd61fc5545dd24407f2f1153188254b7d714f85460f0566b6f482bb0e280810cbb8f2e363440e5aba2de92f45ff5c268bdc03615b982",
-    "otaHeaderString": "GBL Z3C667WaterSensorSDK6760"
+    "otaHeaderString": "GBL Z3C667WaterSensorSDK6760",
+    "modelId": "RBSH-WS-ZB-EU"
   },
   {
     "fileName": "MICROMODULE_LIGHT_SHADING_0x21186A30_PROD.fw",


### PR DESCRIPTION
Within the last weeks, the now available Bosch firmware files were added to the repository. During that process, not all entries got the corresponding `modelId` attribute. This pull request adds it as I'm not sure when it's necessary and when not (e.g. the relay and dimmer updated fine without it).