### PR TITLE
fix: cleanup `customParseLogic` no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Any field not in this list will be ignored. Any field not matching the required 
 - "maxFileVersion": number _(target only devices with this version or below)_
 - "minFileVersion": number _(target only devices with this version or above)_
 - "modelId": string _(target only devices with this model ID)_
-- "customParseLogic": string _(custom parsing logic used for this image)_
 
 ###### For record purpose
 

--- a/index.json
+++ b/index.json
@@ -8624,8 +8624,7 @@
     "imageType": 2064,
     "manufacturerCode": 4742,
     "sha512": "9bd9f188c4b5e45878d72a6b513e9630f4fdc326d1d791d18c9d418971a6a6ad090f81e6e76a5fe800f213d735f116d95f704454212bea8823a13053c5e6a443",
-    "otaHeaderString": "FIRMWARE",
-    "customParseLogic": "telinkEncrypted"
+    "otaHeaderString": "FIRMWARE"
   },
   {
     "fileName": "zbm5-120-zed_v1.0.4.ota",
@@ -8702,8 +8701,7 @@
     "imageType": 2061,
     "manufacturerCode": 4742,
     "sha512": "d84f2e016626b25a5ada1171c920ae31fae57c77edfedc7959c8d2bb56af8c331d8b2bd71346afef7c68ff7672e816faa935262db78aad1b030c99f7bf865879",
-    "otaHeaderString": "Telink OTA Sample Usage",
-    "customParseLogic": "telinkEncrypted"
+    "otaHeaderString": "Telink OTA Sample Usage"
   },
   {
     "fileName": "86-0001-00001101.zigbee",
@@ -8757,8 +8755,7 @@
     "imageType": 2062,
     "manufacturerCode": 4742,
     "sha512": "0ac93af2c1ad69ef9ba3fd923de018f1a1efee2f8c9795372495706b201b4bd4aca2cf3b6cc3046e81a78b7de747ce57f0ae1e42638953983c22a2fc300c5b9a",
-    "otaHeaderString": "FIRMWARE",
-    "customParseLogic": "telinkEncrypted"
+    "otaHeaderString": "FIRMWARE"
   },
   {
     "fileName": "mini-zbdim_v1.0.5.ota",

--- a/src/autodl/sonoff.ts
+++ b/src/autodl/sonoff.ts
@@ -1,6 +1,5 @@
 import {getJson, readCacheJson, writeCacheJson} from "../common.js";
 import {processFirmwareImage} from "../process_firmware_image.js";
-import type {ExtraMetas} from "../types.js";
 
 type DeviceImageJson = {
     fw_binary_url: string;
@@ -16,7 +15,6 @@ type ImagesJson = DeviceImageJson[];
 const NAME = "Sonoff";
 const LOG_PREFIX = `[${NAME}]`;
 const FIRMWARE_URL = "https://zigbee-ota.sonoff.tech/releases/upgrade.json";
-const TELINK_ENCRYPTED = ["SNZB-02DR2", "SNZB-02LWD"];
 
 function findInCache(image: DeviceImageJson, cachedData?: ImagesJson): DeviceImageJson | undefined {
     return cachedData?.find((d) => d.fw_image_type === image.fw_image_type && d.fw_manufacturer_id === image.fw_manufacturer_id) as
@@ -53,9 +51,7 @@ export async function download(): Promise<void> {
                 continue;
             }
 
-            const extraMetas: ExtraMetas = TELINK_ENCRYPTED.includes(image.model_id) ? {customParseLogic: "telinkEncrypted"} : {};
-
-            await processFirmwareImage(NAME, firmwareFileName, image.fw_binary_url, extraMetas);
+            await processFirmwareImage(NAME, firmwareFileName, image.fw_binary_url, {});
         }
 
         writeCacheJson(NAME, images);

--- a/src/common.ts
+++ b/src/common.ts
@@ -309,14 +309,6 @@ export function getValidMetas(metas: Partial<ExtraMetas & ExtraMetasWithFileName
         validMetas.maxFileVersion = metas.maxFileVersion;
     }
 
-    if (metas.customParseLogic != null) {
-        if (metas.customParseLogic !== "telinkEncrypted") {
-            throw new Error(`Invalid value for 'customParseLogic', expected 'telinkEncrypted' value.`);
-        }
-
-        validMetas.customParseLogic = metas.customParseLogic;
-    }
-
     if (metas.minFileVersion != null) {
         if (typeof metas.minFileVersion !== "number") {
             throw new Error(`Invalid format for 'minFileVersion', expected 'number' type.`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,6 @@ export interface RepoImageMeta extends ImageInfo, ImageMeta {
     maxFileVersion?: number;
     originalUrl?: string;
     releaseNotes?: string;
-    customParseLogic?: string;
 }
 
 export type ExtraMetas = Omit<


### PR DESCRIPTION
No longer needed after refactor: https://github.com/Koenkk/zigbee-herdsman/issues/1608 (parsed properly, automatically, based on tag ID)