### PR TITLE
Enable `autodl` for Hue `100b-12d` & `100b-12f`

### DIFF
--- a/src/autodl/hue.ts
+++ b/src/autodl/hue.ts
@@ -44,9 +44,9 @@ const DEVICE_TYPE_IDS: string[] = [
     "100b-12a",
     // '100b-12b',
     // '100b-12c',
-    // '100b-12d',
+    "100b-12d",
     // '100b-12e',
-    // '100b-12f',
+    "100b-12f",
 ];
 
 function sortByVersion(a: ImageJson, b: ImageJson): number {


### PR DESCRIPTION
As there're now firmware images for these Hue devices available, include them for automatic downloads.