### PR TITLE
Legrand: remove v67 NLL firmware (was replaced by v71)

### DIFF
--- a/index.json
+++ b/index.json
@@ -6420,16 +6420,6 @@
     "otaHeaderString": "                                "
   },
   {
-    "fileName": "1021-000f-004345ff-NLL.zigbee",
-    "fileVersion": 4408831,
-    "fileSize": 255127,
-    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-000f-004345ff-NLL.zigbee",
-    "imageType": 15,
-    "manufacturerCode": 4129,
-    "sha512": "aa89a06714e446662dc2f183f0cd72a54dcf344ed62a30ab14b12943eca06857418eba4958398452af60470dc9665e380f155f7d693abb79532d55759b75d772",
-    "otaHeaderString": "                                "
-  },
-  {
     "fileName": "A60_RGBW_T-0x00B6-0x03483712-MF_DIS.OTA",
     "fileVersion": 55064338,
     "fileSize": 256224,


### PR DESCRIPTION
Removing old Legrand firmware v67, which was replaced with v71 in PR #1171.

Currently both v67 and v71 are present in the index, as a result no OTA update is offered by z2m for devices on v67.

I believe this has accidentally been left in the index by the github-action bot in PR #1171 due to back and forth and late adding of `minFileVersion`.

https://github.com/Koenkk/zigbee-OTA/pull/1171#issuecomment-4643200044

Note the record for the new version is still in the index, only the old one is removed, so after this merge we are back to "normal":

```New v71 firmware:

{
    "fileName": "1021-000f-004745ff-NLL.zigbee",
    "fileVersion": 4670975,
    "fileSize": 255143,
    "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/Legrand/1021-000f-004745ff-NLL.zigbee",
    "imageType": 15,
    "manufacturerCode": 4129,
    "sha512": "dc9bb4669f947be422747de971285f917301b343bb1be5e78e7dbbe68988ea1fcaf1eaa0989a22a2f64647f0897c1d45d7967e08f36d2c4c8634a8fd9581efd4",
    "otaHeaderString": "                                ",
    "minFileVersion": 458752
  },```

