### PR TITLE
fix: Add `modelId` for Bosch BTH-RA/-RAD

### DIFF
--- a/index.json
+++ b/index.json
@@ -10129,6 +10129,7 @@
     "manufacturerCode": 4617,
     "sha512": "3fc35c6676c7d655fc6e7fbdde1a838b5bd758bab7a25e5b898f75fddbb873b4a71da1e56889b72bee9e06035d29d1f3963ca5fa26ba2106d1a3de17eca1c539",
     "otaHeaderString": "RBSH-TRV0-ZB-EU",
+    "modelId": "RBSH-TRV0-ZB-EU",
     "releaseNotes": "The value for the valve opening when the battery is very low was reduced to 5% to prevent overheating when the battery is flat and to still guarantee frost protection."
   },
   {
@@ -10140,6 +10141,7 @@
     "manufacturerCode": 4617,
     "sha512": "1f69378387098da6926088d3e676b4d9a75d54bcbeb87f2af67165dd32d2dcda3a3e470d35deb2f1afda91bce6246a8c53488bda31349debe96715082f63417a",
     "otaHeaderString": "TRV_GEN2_DUAL",
+    "modelId": "RBSH-TRV1-ZB-EU",
     "releaseNotes": "The value for the valve opening when the battery is very low was reduced to 5% to prevent overheating when the battery is flat and to still guarantee frost protection."
   }
 ]


### PR DESCRIPTION
My previous PR #1243 didn't include the `modelId` for the new files. That made the GitHub Action not moving the old firmware files into the `images1` folder as well as the devices not discover the new firmware. This PR adds the model IDs and I hope that's enough to make the workflow archiving the old versions.